### PR TITLE
Add Celery task for PDF to EPUB conversion

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,3 +5,5 @@ PyMuPDF==1.24.0
 EbookLib==0.18.0
 pytesseract==0.3.10
 Pillow==10.0.0
+python-dotenv==1.0.1
+

--- a/backend/tasks.py
+++ b/backend/tasks.py
@@ -1,0 +1,53 @@
+import os
+import time
+import logging
+from pathlib import Path
+from celery import Celery
+from dotenv import load_dotenv
+
+# Load environment variables from .env located at repository root
+BASE_DIR = Path(__file__).resolve().parent
+load_dotenv(BASE_DIR.parent / '.env')
+
+# Build Redis URL from environment variables
+redis_host = os.environ.get('REDIS_HOST', 'localhost')
+redis_port = os.environ.get('REDIS_PORT', '6379')
+redis_password = os.environ.get('REDIS_PASSWORD', '')
+redis_auth = f":{redis_password}@" if redis_password else ""
+redis_url = f"redis://{redis_auth}{redis_host}:{redis_port}/0"
+
+broker_url = os.environ.get('CELERY_BROKER_URL', redis_url)
+backend_url = os.environ.get('CELERY_RESULT_BACKEND', redis_url)
+
+celery_app = Celery('tasks', broker=broker_url, backend=backend_url)
+
+from app.converter import EnhancedPDFToEPUBConverter
+converter = EnhancedPDFToEPUBConverter()
+
+@celery_app.task(name='convert_pdf_to_epub')
+def convert_pdf_to_epub(task_id, input_path, output_path=None):
+    """Convert a PDF file to EPUB capturing metrics and errors."""
+    start_time = time.time()
+    try:
+        result = converter.convert(input_path, output_path)
+        duration = time.time() - start_time
+        return {
+            "task_id": task_id,
+            "success": result.get("success", False),
+            "output_path": result.get("output_path"),
+            "message": result.get("message"),
+            "quality_metrics": result.get("quality_metrics"),
+            "engine_used": result.get("engine_used"),
+            "analysis": result.get("analysis"),
+            "duration": duration,
+        }
+    except Exception as exc:
+        duration = time.time() - start_time
+        logging.exception("Error converting PDF to EPUB")
+        return {
+            "task_id": task_id,
+            "success": False,
+            "output_path": None,
+            "message": str(exc),
+            "duration": duration,
+        }


### PR DESCRIPTION
## Summary
- implement Celery task to convert PDF to EPUB and report metrics
- load Redis config from .env and add python-dotenv dependency

## Testing
- `python -m py_compile backend/tasks.py`
- `celery -A tasks worker --loglevel=info` *(fails: Error 111 connecting to localhost:6379)*

------
https://chatgpt.com/codex/tasks/task_e_68c52ce041008320b7fe901a9f6b3c94