### PR TITLE
Add pytest setup and in-memory test fixture

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ source venv/bin/activate  # En Windows: venv\Scripts\activate
 pip install -r requirements.txt
 flask run --port=5175
 La API estará disponible en http://localhost:5175
+Pruebas
+bashpytest
 Estructura del Proyecto
 anclora-pdf2epub/
 ├── frontend/                 # Aplicación React + TypeScript

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -10,3 +10,5 @@ Flask-SQLAlchemy==3.1.1
 Flask-Migrate==4.0.4
 psycopg2-binary==2.9.9
 
+pytest==7.4.3
+pytest-flask==1.3.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,22 @@
+import os
+import sys
+import pytest
+
+# Add backend directory to the Python path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "backend")))
+
+# Configure in-memory databases before importing the app factory
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+os.environ.setdefault("CONVERSION_DB", ":memory:")
+
+from app import create_app, db
+
+@pytest.fixture
+def app():
+    app = create_app()
+    app.config.update({"TESTING": True})
+    with app.app_context():
+        db.create_all()
+        yield app
+        db.session.remove()
+        db.drop_all()


### PR DESCRIPTION
## Summary
- add pytest and pytest-flask to backend requirements
- provide in-memory Flask app fixture for tests
- document running tests with pytest in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c5327b7cd88320ae1463dc7a56dcc5