### PR TITLE
Add authentication forms and protected routing

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,14 +3,17 @@ import { Routes, Route } from 'react-router-dom';
 import Header from './components/Header';
 import ConversionPanel from './components/ConversionPanel';
 import ConversionHistory from './components/ConversionHistory';
+import FileUploader from './components/FileUploader';
+import MetricsDisplay from './components/MetricsDisplay';
+import LoginForm from './LoginForm';
+import RegisterForm from './RegisterForm';
+import ProtectedRoute from './ProtectedRoute';
 
-const App: React.FC = () => {
-
+const MainApp: React.FC = () => {
   const [theme, setTheme] = useState<'light' | 'dark'>('light');
   const [currentSection, setCurrentSection] = useState<string>('inicio');
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
-  
-  // Detectar preferencia de tema del sistema
+
   useEffect(() => {
     document.documentElement.classList.toggle('dark', theme === 'dark');
     localStorage.setItem('theme', theme);
@@ -19,10 +22,9 @@ const App: React.FC = () => {
   const toggleTheme = () => setTheme(theme === 'dark' ? 'light' : 'dark');
 
   return (
-
     <div className={`app-container ${theme}`} data-theme={theme}>
       <Header theme={theme} toggleTheme={toggleTheme} currentSection={currentSection} />
-      
+
       <main className="main-content">
         {currentSection === 'inicio' && (
           <div className="hero-section">
@@ -31,7 +33,7 @@ const App: React.FC = () => {
             <FileUploader onFileSelected={setSelectedFile} />
           </div>
         )}
-        
+
         {currentSection === 'conversion' && (
           <div className="conversion-section">
             <h2>Convertir PDF a EPUB</h2>
@@ -40,17 +42,31 @@ const App: React.FC = () => {
             <MetricsDisplay />
           </div>
         )}
-        
+
         {currentSection === 'history' && (
           <div className="history-section">
             <h2>Historial de Conversiones</h2>
             <ConversionHistory />
           </div>
         )}
-
       </main>
     </div>
   );
 };
+
+const App: React.FC = () => (
+  <Routes>
+    <Route path="/login" element={<LoginForm />} />
+    <Route path="/register" element={<RegisterForm />} />
+    <Route
+      path="/*"
+      element={
+        <ProtectedRoute>
+          <MainApp />
+        </ProtectedRoute>
+      }
+    />
+  </Routes>
+);
 
 export default App;

--- a/frontend/src/AuthContext.tsx
+++ b/frontend/src/AuthContext.tsx
@@ -1,0 +1,65 @@
+import React, { createContext, useContext, useState, ReactNode } from 'react';
+
+interface AuthContextType {
+  token: string | null;
+  login: (username: string, password: string) => Promise<void>;
+  register: (username: string, password: string) => Promise<void>;
+  logout: () => void;
+}
+
+const AuthContext = createContext<AuthContextType | undefined>(undefined);
+
+export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
+  const [token, setToken] = useState<string | null>(() => localStorage.getItem('token'));
+
+  const login = async (username: string, password: string) => {
+    const response = await fetch('/api/auth/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username, password })
+    });
+    if (!response.ok) {
+      throw new Error('Login failed');
+    }
+    const data = await response.json();
+    localStorage.setItem('token', data.token);
+    setToken(data.token);
+  };
+
+  const register = async (username: string, password: string) => {
+    const response = await fetch('/api/auth/register', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username, password })
+    });
+    if (!response.ok) {
+      throw new Error('Registration failed');
+    }
+    const data = await response.json();
+    // If backend returns token on registration
+    if (data.token) {
+      localStorage.setItem('token', data.token);
+      setToken(data.token);
+    }
+  };
+
+  const logout = () => {
+    localStorage.removeItem('token');
+    setToken(null);
+  };
+
+  return (
+    <AuthContext.Provider value={{ token, login, register, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+export const useAuth = (): AuthContextType => {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error('useAuth must be used within an AuthProvider');
+  }
+  return context;
+};
+

--- a/frontend/src/LoginForm.tsx
+++ b/frontend/src/LoginForm.tsx
@@ -1,0 +1,49 @@
+import React, { useState } from 'react';
+import { useNavigate, Link } from 'react-router-dom';
+import { useAuth } from './AuthContext';
+
+const LoginForm: React.FC = () => {
+  const { login } = useAuth();
+  const navigate = useNavigate();
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      await login(username, password);
+      navigate('/');
+    } catch (err) {
+      setError('Credenciales inválidas');
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="p-4 flex flex-col gap-2">
+      <h2>Iniciar sesión</h2>
+      {error && <p className="text-red-500">{error}</p>}
+      <input
+        type="text"
+        placeholder="Usuario"
+        value={username}
+        onChange={(e) => setUsername(e.target.value)}
+        className="border p-2"
+      />
+      <input
+        type="password"
+        placeholder="Contraseña"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        className="border p-2"
+      />
+      <button type="submit" className="bg-blue-500 text-white p-2">Entrar</button>
+      <p>
+        ¿No tienes cuenta? <Link to="/register" className="text-blue-500">Regístrate</Link>
+      </p>
+    </form>
+  );
+};
+
+export default LoginForm;
+

--- a/frontend/src/ProtectedRoute.tsx
+++ b/frontend/src/ProtectedRoute.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { Navigate } from 'react-router-dom';
+import { useAuth } from './AuthContext';
+
+const ProtectedRoute: React.FC<{ children: JSX.Element }> = ({ children }) => {
+  const { token } = useAuth();
+  if (!token) {
+    return <Navigate to="/login" replace />;
+  }
+  return children;
+};
+
+export default ProtectedRoute;
+

--- a/frontend/src/RegisterForm.tsx
+++ b/frontend/src/RegisterForm.tsx
@@ -1,0 +1,49 @@
+import React, { useState } from 'react';
+import { useNavigate, Link } from 'react-router-dom';
+import { useAuth } from './AuthContext';
+
+const RegisterForm: React.FC = () => {
+  const { register } = useAuth();
+  const navigate = useNavigate();
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      await register(username, password);
+      navigate('/login');
+    } catch (err) {
+      setError('Registro fallido');
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="p-4 flex flex-col gap-2">
+      <h2>Crear cuenta</h2>
+      {error && <p className="text-red-500">{error}</p>}
+      <input
+        type="text"
+        placeholder="Usuario"
+        value={username}
+        onChange={(e) => setUsername(e.target.value)}
+        className="border p-2"
+      />
+      <input
+        type="password"
+        placeholder="Contraseña"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        className="border p-2"
+      />
+      <button type="submit" className="bg-green-500 text-white p-2">Registrarse</button>
+      <p>
+        ¿Ya tienes cuenta? <Link to="/login" className="text-blue-500">Inicia sesión</Link>
+      </p>
+    </form>
+  );
+};
+
+export default RegisterForm;
+

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import App from './App';
 import './index.css';
+import { AuthProvider } from './AuthContext';
 
 // establecer tema inicial
 const storedTheme = localStorage.getItem('theme');
@@ -16,7 +17,9 @@ if (
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
     <BrowserRouter>
-      <App />
+      <AuthProvider>
+        <App />
+      </AuthProvider>
     </BrowserRouter>
   </React.StrictMode>
 );


### PR DESCRIPTION
## Summary
- add AuthContext with login/register handling tokens in localStorage
- create LoginForm and RegisterForm components
- protect routes using context and redirect unauthenticated users

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c53b83169c83208d6ed4ee14d93e9f