### PR TITLE
Add JWT-based authentication and user model

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ REDIS_PASSWORD=anclora_redis_password
 FLASK_ENV=development
 FLASK_APP=app
 SECRET_KEY=anclora_dev_secret_key
+# Configuración JWT
+JWT_SECRET=anclora_jwt_secret
+JWT_EXPIRATION=3600
 
 # Configuración de almacenamiento
 UPLOAD_FOLDER=uploads

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -19,10 +19,15 @@ def create_app():
         CONVERSION_TIMEOUT=int(os.environ.get('CONVERSION_TIMEOUT', 300)),
         SQLALCHEMY_DATABASE_URI=os.environ.get('DATABASE_URL', 'sqlite:///app.db'),
         SQLALCHEMY_TRACK_MODIFICATIONS=False,
+        JWT_SECRET=os.environ.get('JWT_SECRET', 'dev'),
+        JWT_EXPIRATION=int(os.environ.get('JWT_EXPIRATION', 3600)),
     )
 
     db.init_app(app)
     migrate.init_app(app, db)
+
+    with app.app_context():
+        db.create_all()
     
     # Asegurarse de que existan los directorios
     os.makedirs(app.config['UPLOAD_FOLDER'], exist_ok=True)
@@ -31,7 +36,9 @@ def create_app():
     # Inicializar base de datos y registrar rutas
     init_db()
     from . import routes
+    from .auth import auth_bp
     app.register_blueprint(routes.bp)
+    app.register_blueprint(auth_bp)
 
     return app
 

--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -1,0 +1,74 @@
+from datetime import datetime, timedelta
+from functools import wraps
+
+import jwt
+from flask import Blueprint, request, jsonify, current_app
+from werkzeug.security import generate_password_hash, check_password_hash
+
+from . import db
+
+
+class User(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    email = db.Column(db.String(120), unique=True, nullable=False)
+    password_hash = db.Column(db.String(255), nullable=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+
+auth_bp = Blueprint("auth", __name__, url_prefix="/api/auth")
+
+
+def _generate_token(user_id):
+    exp_seconds = current_app.config.get("JWT_EXPIRATION", 3600)
+    payload = {"user_id": user_id, "exp": datetime.utcnow() + timedelta(seconds=exp_seconds)}
+    token = jwt.encode(payload, current_app.config["JWT_SECRET"], algorithm="HS256")
+    return token
+
+
+def token_required(f):
+    @wraps(f)
+    def decorated(*args, **kwargs):
+        auth_header = request.headers.get("Authorization", "")
+        if not auth_header.lower().startswith("bearer "):
+            return jsonify({"error": "Missing token"}), 401
+        token = auth_header.split(" ", 1)[1]
+        try:
+            data = jwt.decode(token, current_app.config["JWT_SECRET"], algorithms=["HS256"])
+            user = User.query.get(data.get("user_id"))
+            if user is None:
+                raise jwt.InvalidTokenError
+        except Exception:
+            return jsonify({"error": "Invalid token"}), 401
+        return f(*args, **kwargs)
+
+    return decorated
+
+
+@auth_bp.route("/register", methods=["POST"])
+def register():
+    data = request.get_json() or {}
+    email = data.get("email")
+    password = data.get("password")
+    if not email or not password:
+        return jsonify({"error": "Missing email or password"}), 400
+    if User.query.filter_by(email=email).first():
+        return jsonify({"error": "User already exists"}), 400
+    user = User(email=email, password_hash=generate_password_hash(password))
+    db.session.add(user)
+    db.session.commit()
+    token = _generate_token(user.id)
+    return jsonify({"token": token}), 201
+
+
+@auth_bp.route("/login", methods=["POST"])
+def login():
+    data = request.get_json() or {}
+    email = data.get("email")
+    password = data.get("password")
+    if not email or not password:
+        return jsonify({"error": "Missing email or password"}), 400
+    user = User.query.filter_by(email=email).first()
+    if user is None or not check_password_hash(user.password_hash, password):
+        return jsonify({"error": "Invalid credentials"}), 401
+    token = _generate_token(user.id)
+    return jsonify({"token": token})

--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -6,6 +6,7 @@ import uuid
 
 from .tasks import convert_pdf_to_epub, celery_app
 from .models import create_conversion, fetch_conversions
+from .auth import token_required
 
 bp = Blueprint('routes', __name__)
 
@@ -16,6 +17,7 @@ def allowed_file(filename):
     return '.' in filename and filename.rsplit('.', 1)[1].lower() in ALLOWED_EXTENSIONS
 
 @bp.route('/api/convert', methods=['POST'])
+@token_required
 def convert():
     if 'file' not in request.files:
         return jsonify({'error': 'No file part'}), 400
@@ -43,6 +45,7 @@ def convert():
     return jsonify({'task_id': task_id}), 202
 
 @bp.route('/api/status/<task_id>', methods=['GET'])
+@token_required
 def task_status(task_id):
     result = AsyncResult(task_id, app=celery_app)
     response = {
@@ -57,6 +60,7 @@ def task_status(task_id):
 
 
 @bp.route('/api/history', methods=['GET'])
+@token_required
 def history():
     page = int(request.args.get('page', 1))
     per_page = int(request.args.get('per_page', 10))

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -9,6 +9,7 @@ python-dotenv==1.0.1
 Flask-SQLAlchemy==3.1.1
 Flask-Migrate==4.0.4
 psycopg2-binary==2.9.9
+PyJWT==2.8.0
 
 pytest==7.4.3
 pytest-flask==1.3.0

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,0 +1,29 @@
+import os
+import sys
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from app import create_app
+
+
+def _setup_app(tmpdir):
+    os.environ['UPLOAD_FOLDER'] = str(tmpdir / 'uploads')
+    os.environ['RESULTS_FOLDER'] = str(tmpdir / 'results')
+    os.environ['CONVERSION_DB'] = str(tmpdir / 'conv.db')
+    os.environ['DATABASE_URL'] = 'sqlite:///' + str(tmpdir / 'app.db')
+    os.environ['JWT_SECRET'] = 'test-secret'
+    return create_app()
+
+
+def test_register_and_login(tmp_path):
+    app = _setup_app(tmp_path)
+    client = app.test_client()
+
+    resp = client.post('/api/auth/register', json={'email': 'a@a.com', 'password': 'pw'})
+    assert resp.status_code == 201
+    token = resp.get_json().get('token')
+    assert token
+
+    resp = client.post('/api/auth/login', json={'email': 'a@a.com', 'password': 'pw'})
+    assert resp.status_code == 200
+    assert resp.get_json().get('token')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..",
 # Configure in-memory databases before importing the app factory
 os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
 os.environ.setdefault("CONVERSION_DB", ":memory:")
+os.environ.setdefault("JWT_SECRET", "test-secret")
 
 from app import create_app, db
 


### PR DESCRIPTION
## Summary
- add SQLAlchemy `User` model and JWT auth blueprint
- secure existing endpoints with token verification decorator
- document new JWT environment variables and dependency

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c53b7be20c83208253c3da7b68a51d