### PR TITLE
Add language-aware OCR and smarter PDF analysis

### DIFF
--- a/backend/app/converter.py
+++ b/backend/app/converter.py
@@ -5,6 +5,8 @@ from ebooklib import epub
 from enum import Enum
 import pytesseract
 from PIL import Image
+import io
+from langdetect import detect, LangDetectException
 import tempfile
 import uuid
 import logging
@@ -12,6 +14,41 @@ import logging
 # Configurar logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+
+TESSERACT_LANG_MAP = {
+    'en': 'eng',
+    'es': 'spa',
+    'fr': 'fra',
+    'de': 'deu',
+    'it': 'ita',
+    'pt': 'por',
+}
+
+
+def get_ocr_lang(detected_lang):
+    base = TESSERACT_LANG_MAP.get(detected_lang, 'eng')
+    if base != 'eng':
+        return f"{base}+eng"
+    return base
+
+
+def compress_image(image_bytes, image_ext):
+    try:
+        with Image.open(io.BytesIO(image_bytes)) as img:
+            buffer = io.BytesIO()
+            if img.format == 'PNG':
+                img.save(buffer, format='PNG', optimize=True)
+            else:
+                img.save(buffer, format='JPEG', quality=70, optimize=True)
+            compressed = buffer.getvalue()
+            if len(compressed) < len(image_bytes):
+                logger.info(
+                    f"Image compressed from {len(image_bytes)} to {len(compressed)} bytes"
+                )
+                return compressed
+    except Exception as e:
+        logger.warning(f"Image compression failed: {e}")
+    return image_bytes
 
 class ContentType(Enum):
     TEXT_ONLY = "text_only"
@@ -27,9 +64,9 @@ class ConversionEngine(Enum):
     QUALITY = "quality"
 
 class PDFAnalysis:
-    def __init__(self, page_count, file_size, text_extractable, 
-                 image_count, content_type, issues, complexity_score, 
-                 recommended_engine):
+    def __init__(self, page_count, file_size, text_extractable,
+                 image_count, content_type, issues, complexity_score,
+                 recommended_engine, language=None):
         self.page_count = page_count
         self.file_size = file_size
         self.text_extractable = text_extractable
@@ -38,78 +75,94 @@ class PDFAnalysis:
         self.issues = issues
         self.complexity_score = complexity_score
         self.recommended_engine = recommended_engine
+        self.language = language
 
 class PDFAnalyzer:
+    IMAGE_HEAVY_RATIO = 1.5
+    TABLE_KEYWORDS = ["table", "tabla", "tabella", "tabelle", "tableau"]
+
     def analyze_pdf(self, pdf_path):
         """Analiza un PDF y devuelve métricas y recomendaciones"""
-        
+
         # 1. Métricas básicas
         file_size = os.path.getsize(pdf_path)
-        
+
         try:
             doc = fitz.open(pdf_path)
             page_count = len(doc)
-            
+
             # 2. Análisis de contenido
             text_length = 0
             image_count = 0
-            
+
             for page in doc:
                 text_length += len(page.get_text())
                 image_count += len(page.get_images())
-            
+
             text_extractable = text_length > 0
-            
+
             # 3. Determinar tipo de contenido
             if not text_extractable and image_count > 0:
                 content_type = ContentType.SCANNED_DOCUMENT
-            elif image_count > page_count * 2:
+            elif image_count > page_count * self.IMAGE_HEAVY_RATIO:
                 content_type = ContentType.IMAGE_HEAVY
             elif image_count > 0:
                 content_type = ContentType.TEXT_WITH_IMAGES
             else:
                 content_type = ContentType.TEXT_ONLY
-                
+
+            detected_language = None
+            text_sample = ""
+
             # Detección específica para documentos académicos o técnicos
             if text_extractable:
-                text_sample = ""
                 for i in range(min(5, page_count)):
                     text_sample += doc[i].get_text()
-                
-                if any(marker in text_sample.lower() for marker in 
+
+                if text_sample.strip():
+                    try:
+                        detected_language = detect(text_sample)
+                    except LangDetectException:
+                        detected_language = None
+
+                if any(marker in text_sample.lower() for marker in
                        ["abstract", "keywords", "references", "bibliography", "doi"]):
                     content_type = ContentType.ACADEMIC_PAPER
-                
-                if any(marker in text_sample.lower() for marker in 
+
+                if any(marker in text_sample.lower() for marker in
                        ["figure", "table", "diagram", "appendix", "specification"]):
                     content_type = ContentType.TECHNICAL_MANUAL
-            
+
             # 4. Detectar problemas
             issues = []
-            
+
             if not text_extractable:
                 issues.append("No text extractable, OCR required")
-            
+
             if image_count == 0 and page_count > 0:
                 issues.append("No images detected")
-            
+
             # Verificar si hay tablas
-            has_tables = False
+            table_hits = 0
             for page in doc:
-                if "table" in page.get_text().lower():
-                    has_tables = True
-                    break
-            
+                text_lower = page.get_text().lower()
+                for kw in self.TABLE_KEYWORDS:
+                    if kw in text_lower:
+                        table_hits += 1
+                        break
+
+            has_tables = table_hits >= 2
+
             if has_tables:
                 issues.append("Tables detected, may require special handling")
-            
+
             # 5. Calcular complejidad
-            complexity_score = min(5, 1 + 
-                                 (0 if text_extractable else 2) + 
-                                 (0 if image_count < page_count else 1) + 
-                                 (0 if not has_tables else 1) + 
+            complexity_score = min(5, 1 +
+                                 (0 if text_extractable else 2) +
+                                 (0 if image_count < page_count * 0.8 else 1) +
+                                 (0 if not has_tables else 1) +
                                  (0 if page_count < 20 else 1))
-            
+
             # 6. Recomendar motor
             if complexity_score <= 1:
                 recommended_engine = ConversionEngine.RAPID
@@ -117,7 +170,7 @@ class PDFAnalyzer:
                 recommended_engine = ConversionEngine.BALANCED
             else:
                 recommended_engine = ConversionEngine.QUALITY
-            
+
             return PDFAnalysis(
                 page_count=page_count,
                 file_size=file_size,
@@ -126,9 +179,10 @@ class PDFAnalyzer:
                 content_type=content_type,
                 issues=issues,
                 complexity_score=complexity_score,
-                recommended_engine=recommended_engine
+                recommended_engine=recommended_engine,
+                language=detected_language
             )
-            
+
         except Exception as e:
             logger.error(f"Error analyzing PDF: {str(e)}")
             # Retornar análisis por defecto con recomendación de motor de calidad
@@ -140,7 +194,8 @@ class PDFAnalyzer:
                 content_type=ContentType.SCANNED_DOCUMENT,
                 issues=["Error analyzing PDF"],
                 complexity_score=5,
-                recommended_engine=ConversionEngine.QUALITY
+                recommended_engine=ConversionEngine.QUALITY,
+                language=None
             )
 
 class BaseConverter:
@@ -161,7 +216,7 @@ class RapidConverter(BaseConverter):
             
             if 'author' in metadata:
                 book.add_author(metadata['author'])
-            
+
             # Abrir PDF
             pdf = fitz.open(pdf_path)
             
@@ -254,7 +309,7 @@ class BalancedConverter(BaseConverter):
             
             if 'author' in metadata:
                 book.add_author(metadata['author'])
-            
+
             # Abrir PDF
             pdf = fitz.open(pdf_path)
             
@@ -300,7 +355,7 @@ class BalancedConverter(BaseConverter):
                         uid=f"image_p{i+1}_{img_index}",
                         file_name=image_filename,
                         media_type=f"image/{image_ext}",
-                        content=image_bytes
+                        content=compress_image(image_bytes, image_ext)
                     )
                     
                     book.add_item(epub_image)
@@ -374,6 +429,8 @@ class BalancedConverter(BaseConverter):
 
 class QualityConverter(BaseConverter):
     """Conversión de alta calidad para documentos complejos, incluye OCR"""
+    TEXT_OCR_THRESHOLD = 80
+
     def convert(self, pdf_path, output_path, analysis, metadata=None):
         try:
             # Crear EPUB
@@ -385,7 +442,9 @@ class QualityConverter(BaseConverter):
             
             if 'author' in metadata:
                 book.add_author(metadata['author'])
-            
+
+            ocr_lang = metadata.get('ocr_languages', 'eng')
+
             # Abrir PDF
             pdf = fitz.open(pdf_path)
             
@@ -397,7 +456,7 @@ class QualityConverter(BaseConverter):
                 for i, page in enumerate(pdf):
                     # Intentar extraer texto
                     text = page.get_text()
-                    needs_ocr = len(text.strip()) < 50  # Umbral arbitrario
+                    needs_ocr = len(text.strip()) < self.TEXT_OCR_THRESHOLD
                     
                     # Si no hay suficiente texto, aplicar OCR
                     if needs_ocr:
@@ -408,7 +467,7 @@ class QualityConverter(BaseConverter):
                         
                         # Aplicar OCR
                         img = Image.open(img_path)
-                        text = pytesseract.image_to_string(img, lang='spa+eng')
+                        text = pytesseract.image_to_string(img, lang=ocr_lang)
                     
                     # Crear capítulo
                     chapter = epub.EpubHtml(
@@ -441,10 +500,12 @@ class QualityConverter(BaseConverter):
                         base_image = pdf.extract_image(xref)
                         image_bytes = base_image["image"]
                         image_ext = base_image["ext"]
-                        
+
+                        image_bytes = compress_image(image_bytes, image_ext)
+
                         # Generar nombre único para la imagen
                         image_filename = f"images/image_p{i+1}_{img_index}.{image_ext}"
-                        
+
                         # Crear objeto imagen para EPUB
                         epub_image = epub.EpubItem(
                             uid=f"image_p{i+1}_{img_index}",
@@ -576,7 +637,11 @@ class EnhancedPDFToEPUBConverter:
             # 1. Analizar PDF
             logger.info(f"Analyzing PDF: {pdf_path}")
             analysis = self.analyzer.analyze_pdf(pdf_path)
-            
+
+            if analysis.language:
+                metadata['language'] = analysis.language
+            metadata['ocr_languages'] = get_ocr_lang(analysis.language)
+
             # 2. Seleccionar motor
             selected_engine = engine or analysis.recommended_engine
             logger.info(f"Using conversion engine: {selected_engine.value}")
@@ -600,7 +665,8 @@ class EnhancedPDFToEPUBConverter:
                 "file_size": analysis.file_size,
                 "content_type": analysis.content_type.value,
                 "complexity_score": analysis.complexity_score,
-                "issues": analysis.issues
+                "issues": analysis.issues,
+                "language": analysis.language,
             }
             
             return result

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,6 +5,7 @@ PyMuPDF==1.24.0
 EbookLib==0.18.0
 pytesseract==0.3.10
 Pillow==10.0.0
+langdetect==1.0.9
 python-dotenv==1.0.1
 Flask-SQLAlchemy==3.1.1
 Flask-Migrate==4.0.4


### PR DESCRIPTION
## Summary
- detect PDF language via langdetect and map to Tesseract dictionaries
- refine analyzer thresholds for tables and image density
- compress images before embedding and honor detected language during OCR

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c53b997ae48320aec7df20c41c9b84