### PR TITLE
fix: deduplicate prometheus-client dependency

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -12,8 +12,7 @@ Flask-Migrate==4.0.4
 psycopg2-binary==2.9.9
 PyJWT==2.8.0
 Flask-Limiter==3.5.0
-prometheus-client==0.20.0
+prometheus-client==0.22.1
 
 pytest==7.4.3
 pytest-flask==1.3.0
-prometheus-client==0.22.1


### PR DESCRIPTION
## Summary
- remove duplicate prometheus-client entry and pin to version 0.22.1

## Testing
- `pip install -r backend/requirements.txt`
- `pip install -r backend/requirements-test.txt`
- `pytest` *(fails: name 'auth_bp' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68c552fb723c8320b604a95ca81c2551