### PR TITLE
refactor: cleanup limiter and auth blueprint

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,4 +1,4 @@
-from flask import Flask, Response, request
+from flask import Flask, Response, request, jsonify, current_app
 from flask_sqlalchemy import SQLAlchemy
 from flask_migrate import Migrate
 from flask_limiter import Limiter
@@ -10,15 +10,13 @@ import logging
 import json
 from prometheus_client import Counter, Histogram, generate_latest, CONTENT_TYPE_LATEST
 from .models import init_db
-from flask_limiter import Limiter
-from flask_limiter.util import get_remote_address
 
 db = SQLAlchemy()
-limit_value = lambda: os.environ.get('RATE_LIMIT', '5 per minute')
-limiter = Limiter(get_remote_address, default_limits=[limit_value])
 migrate = Migrate()
-limiter = Limiter(key_func=get_remote_address,
-                  default_limits=["200 per day", "50 per hour"])
+limit_value = lambda: current_app.config.get('RATE_LIMIT', '5 per minute')
+limiter = Limiter(key_func=get_remote_address, default_limits=[limit_value])
+
+from .auth import auth_bp
 
 
 class JsonFormatter(logging.Formatter):


### PR DESCRIPTION
## Summary
- ensure limiter uses RATE_LIMIT from environment and only initializes once
- import auth blueprint and jsonify in app factory

## Testing
- `pytest` *(fails: test_register_login_and_access, test_metrics_and_logs, test_api_convert_returns_task_id, test_rejects_invalid_mime_and_logs, test_sanitizes_filename, test_api_status_returns_result)*

------
https://chatgpt.com/codex/tasks/task_e_68c552da20ac8320b000e02f643111a2