### PR TITLE
feat: add pipeline analysis selection before conversion

### DIFF
--- a/frontend/src/components/ConversionPanel.tsx
+++ b/frontend/src/components/ConversionPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../AuthContext';
 
@@ -11,11 +11,55 @@ const ConversionPanel: React.FC<ConversionPanelProps> = ({ file }) => {
   const [status, setStatus] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [isConverting, setIsConverting] = useState<boolean>(false);
+  const [isAnalyzing, setIsAnalyzing] = useState<boolean>(false);
+  const [pipelines, setPipelines] = useState<Array<{ id: string; quality: string; estimated_time: number }>>([]);
+  const [selectedPipeline, setSelectedPipeline] = useState<string>('');
   const { token, logout } = useAuth();
   const navigate = useNavigate();
 
-  const startConversion = async () => {
+  const analyzeFile = async () => {
     if (!file) return;
+    setError(null);
+    setIsAnalyzing(true);
+    setPipelines([]);
+    setSelectedPipeline('');
+    try {
+      const formData = new FormData();
+      formData.append('file', file);
+      const res = await fetch('/api/analyze', {
+        method: 'POST',
+        body: formData,
+        headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+      });
+      if (res.status === 401) {
+        logout();
+        navigate('/login');
+        setIsAnalyzing(false);
+        return;
+      }
+      const data = await res.json();
+      if (!res.ok) {
+        throw new Error(data.error || 'Error al analizar');
+      }
+      setPipelines(data.pipelines || []);
+    } catch (err: any) {
+      setError(err.message);
+    } finally {
+      setIsAnalyzing(false);
+    }
+  };
+
+  useEffect(() => {
+    if (file) {
+      analyzeFile();
+    } else {
+      setPipelines([]);
+      setSelectedPipeline('');
+    }
+  }, [file]);
+
+  const startConversion = async () => {
+    if (!file || !selectedPipeline) return;
     setError(null);
     setTaskId(null);
     setStatus(null);
@@ -23,6 +67,7 @@ const ConversionPanel: React.FC<ConversionPanelProps> = ({ file }) => {
     try {
       const formData = new FormData();
       formData.append('file', file);
+      formData.append('pipeline_id', selectedPipeline);
       const res = await fetch('/api/convert', {
         method: 'POST',
         body: formData,
@@ -91,7 +136,29 @@ const ConversionPanel: React.FC<ConversionPanelProps> = ({ file }) => {
 
   return (
     <div className="conversion-panel">
-      <button onClick={startConversion} disabled={!file || isConverting}>
+      {isAnalyzing && <p>Analizando...</p>}
+      {pipelines.length > 0 && (
+        <div className="pipeline-list">
+          <h3>Opciones de conversión</h3>
+          <ul>
+            {pipelines.map((p) => (
+              <li key={p.id}>
+                <label>
+                  <input
+                    type="radio"
+                    name="pipeline"
+                    value={p.id}
+                    checked={selectedPipeline === p.id}
+                    onChange={() => setSelectedPipeline(p.id)}
+                  />
+                  {p.quality} - {p.estimated_time}s
+                </label>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+      <button onClick={startConversion} disabled={!file || !selectedPipeline || isConverting}>
         {isConverting ? 'Convirtiendo...' : 'Enviar a convertir'}
       </button>
       {taskId && <p>Task ID: {taskId}</p>}


### PR DESCRIPTION
## Summary
- analyze uploaded PDF for conversion options
- allow choosing pipeline and send pipeline_id on convert
- display analysis options and progress messages

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c55b1fffec83208703443528937305