### PR TITLE
Add conversion cache with expiration and cleanup

### DIFF
--- a/backend/app/pipeline.py
+++ b/backend/app/pipeline.py
@@ -13,6 +13,7 @@ Example:
 
 from __future__ import annotations
 
+import hashlib
 import logging
 import os
 import shutil
@@ -48,6 +49,74 @@ class StepResult:
     duration: float
     output: Optional[str] = None
     error: Optional[str] = None
+
+
+class ConversionCache:
+    """Simple filesystem based cache for conversion step outputs.
+
+    Entries are stored under a cache directory using a filename derived from
+    the SHA256 hash of the input file and the step name.  Cached files expire
+    after ``expiry_seconds`` and a lightweight cleanup runs periodically to
+    remove stale entries.
+    """
+
+    def __init__(self, cache_dir: Optional[str] = None, expiry_seconds: int = 3600) -> None:
+        self.cache_dir = cache_dir or os.path.join(tempfile.gettempdir(), "conversion_cache")
+        self.expiry_seconds = expiry_seconds
+        os.makedirs(self.cache_dir, exist_ok=True)
+        self._last_cleanup = 0.0
+
+    # ------------------------------------------------------------------
+    def _hash_file(self, path: str) -> str:
+        hasher = hashlib.sha256()
+        with open(path, "rb") as f:
+            for chunk in iter(lambda: f.read(8192), b""):
+                hasher.update(chunk)
+        return hasher.hexdigest()
+
+    def _cache_path(self, file_hash: str, step: str, ext: str) -> str:
+        name = f"{file_hash}-{step}{ext}"
+        return os.path.join(self.cache_dir, name)
+
+    # ------------------------------------------------------------------
+    def get(self, input_path: str, step: str) -> Optional[str]:
+        """Return cached file for ``step`` and ``input_path`` if valid."""
+        self.cleanup()
+        file_hash = self._hash_file(input_path)
+        prefix = f"{file_hash}-{step}"
+        for fname in os.listdir(self.cache_dir):
+            if fname.startswith(prefix):
+                path = os.path.join(self.cache_dir, fname)
+                if time.time() - os.path.getmtime(path) < self.expiry_seconds:
+                    return path
+                try:
+                    os.remove(path)
+                except OSError:
+                    pass
+        return None
+
+    def set(self, input_path: str, step: str, output_path: str) -> str:
+        """Store ``output_path`` result for ``step`` keyed by ``input_path``."""
+        file_hash = self._hash_file(input_path)
+        ext = os.path.splitext(output_path)[1]
+        dest = self._cache_path(file_hash, step, ext)
+        shutil.copy2(output_path, dest)
+        return dest
+
+    # ------------------------------------------------------------------
+    def cleanup(self) -> None:
+        """Remove expired cache entries periodically."""
+        now = time.time()
+        if now - self._last_cleanup < self.expiry_seconds:
+            return
+        for fname in os.listdir(self.cache_dir):
+            path = os.path.join(self.cache_dir, fname)
+            if now - os.path.getmtime(path) > self.expiry_seconds:
+                try:
+                    os.remove(path)
+                except OSError:
+                    pass
+        self._last_cleanup = now
 
 
 class PandocAdapter:
@@ -106,8 +175,9 @@ class ConversionPipeline:
     pipeline stops and returns the collected metrics along with the error.
     """
 
-    def __init__(self, steps: List[str]):
+    def __init__(self, steps: List[str], cache: Optional[ConversionCache] = None):
         self.steps = steps
+        self.cache = cache or ConversionCache()
         self.adapters = {
             "pdf2htmlex": Pdf2HtmlEXAdapter(),
             "pandoc": PandocAdapter(),
@@ -120,14 +190,20 @@ class ConversionPipeline:
 
         for step in self.steps:
             adapter = self.adapters[step]
-            if step == "pandoc":
-                output_fd, output_path = tempfile.mkstemp(suffix=".epub")
-                os.close(output_fd)
-                result = adapter.run(current, output_path)
-                final_output = output_path if result.success else None
-            else:  # pdf2htmlex
-                result = adapter.run(current)
-                current = result.output or current
+
+            cached_output = self.cache.get(current, step)
+            if cached_output:
+                result = StepResult(True, 0.0, output=cached_output)
+            else:
+                if step == "pandoc":
+                    output_fd, output_path = tempfile.mkstemp(suffix=".epub")
+                    os.close(output_fd)
+                    result = adapter.run(current, output_path)
+                else:  # pdf2htmlex
+                    result = adapter.run(current)
+
+                if result.success and result.output:
+                    result.output = self.cache.set(current, step, result.output)
 
             metrics.append(
                 {
@@ -139,5 +215,10 @@ class ConversionPipeline:
 
             if not result.success:
                 return {"success": False, "error": result.error, "metrics": metrics}
+
+            if step == "pandoc":
+                final_output = result.output
+            else:
+                current = result.output or current
 
         return {"success": True, "output": final_output or current, "metrics": metrics}

--- a/backend/tests/test_cache_pipeline.py
+++ b/backend/tests/test_cache_pipeline.py
@@ -1,0 +1,74 @@
+import os
+import sys
+import tempfile
+import time
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from app.pipeline import ConversionPipeline, StepResult, ConversionCache
+
+
+class DummyPdfAdapter:
+    def __init__(self):
+        self.calls = 0
+
+    def run(self, input_path):
+        self.calls += 1
+        fd, output_path = tempfile.mkstemp(suffix=".html")
+        os.close(fd)
+        with open(output_path, "w", encoding="utf-8") as f:
+            f.write("html")
+        return StepResult(True, 0.01, output=output_path)
+
+
+class DummyPandocAdapter:
+    def __init__(self):
+        self.calls = 0
+
+    def run(self, input_path, output_path):
+        self.calls += 1
+        with open(output_path, "w", encoding="utf-8") as f:
+            f.write("epub")
+        return StepResult(True, 0.01, output=output_path)
+
+
+def test_pipeline_uses_cache(monkeypatch, tmp_path):
+    pdf_path = tmp_path / "in.pdf"
+    pdf_path.write_text("dummy")
+
+    html_adapter = DummyPdfAdapter()
+    epub_adapter = DummyPandocAdapter()
+    monkeypatch.setattr("app.pipeline.Pdf2HtmlEXAdapter", lambda: html_adapter)
+    monkeypatch.setattr("app.pipeline.PandocAdapter", lambda: epub_adapter)
+
+    pipeline = ConversionPipeline(["pdf2htmlex", "pandoc"], cache=ConversionCache())
+
+    first = pipeline.run(str(pdf_path))
+    assert first["success"] is True
+    assert html_adapter.calls == 1
+    assert epub_adapter.calls == 1
+
+    second = pipeline.run(str(pdf_path))
+    assert second["success"] is True
+    assert html_adapter.calls == 1
+    assert epub_adapter.calls == 1
+    assert first["output"] == second["output"]
+
+
+def test_cache_expiration(tmp_path):
+    cache = ConversionCache(expiry_seconds=1)
+    inp = tmp_path / "file.txt"
+    out = tmp_path / "out.txt"
+    inp.write_text("x")
+    out.write_text("y")
+
+    cached = cache.set(str(inp), "step", str(out))
+    assert cache.get(str(inp), "step") == cached
+
+    # Force the cache file to appear old and trigger cleanup
+    old = time.time() - 3600
+    os.utime(cached, (old, old))
+    cache._last_cleanup = 0
+    cache.cleanup()
+    assert not os.path.exists(cached)
+    assert cache.get(str(inp), "step") is None


### PR DESCRIPTION
## Summary
- implement `ConversionCache` to persist step outputs by hashed input and clean expired items
- use cache within `ConversionPipeline` to skip already-processed steps
- add unit tests for cache reuse and expiration

## Testing
- `pytest backend/tests/test_cache_pipeline.py -q`
- `pytest` *(fails: ImportError: cannot import name 'evaluate_sequences')*

------
https://chatgpt.com/codex/tasks/task_e_68c56a9df5f48320a8cd466b25e912ac