### PR TITLE
Add conversion progress feedback

### DIFF
--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -194,6 +194,12 @@ def task_status(task_id):
         response['result'] = result.result
     elif result.state == 'FAILURE':
         response['error'] = str(result.info)
+    elif result.info:
+        # For PROGRESS or other intermediate states
+        if isinstance(result.info, dict):
+            response.update(result.info)
+        else:
+            response['message'] = str(result.info)
     return jsonify(response)
 
 

--- a/backend/app/tasks.py
+++ b/backend/app/tasks.py
@@ -82,9 +82,9 @@ def _task_postrun(sender=None, task_id=None, state=None, **kwargs):  # pragma: n
     )
 
 
-@celery_app.task(name="convert_pdf_to_epub")
+@celery_app.task(bind=True, name="convert_pdf_to_epub")
 
-def convert_pdf_to_epub(task_id, input_path, output_path=None, pipeline=None):
+def convert_pdf_to_epub(self, task_id, input_path, output_path=None, pipeline=None):
     """Convert a PDF to EPUB executing each step in the provided pipeline.
 
     Args:
@@ -97,6 +97,7 @@ def convert_pdf_to_epub(task_id, input_path, output_path=None, pipeline=None):
 
     start_time = time.time()
     pipeline = pipeline or ["conversion"]
+    total_steps = len(pipeline)
     pipeline_metrics = []
 
     from . import create_app
@@ -108,7 +109,12 @@ def convert_pdf_to_epub(task_id, input_path, output_path=None, pipeline=None):
     )
 
     context = {}
-    for step in pipeline:
+    for i, step in enumerate(pipeline):
+        progress = int((i / total_steps) * 100)
+        self.update_state(
+            state="PROGRESS",
+            meta={"progress": progress, "message": f"Iniciando {step}"},
+        )
         step_start = time.time()
         step_status = "SUCCESS"
         try:
@@ -180,18 +186,24 @@ def convert_pdf_to_epub(task_id, input_path, output_path=None, pipeline=None):
                     conv.status = step.upper()
                 db.session.commit()
         if step_status == "FAILURE":
+            error_msg = context.get(step, {}).get("error", "Unknown error")
             total_duration = time.time() - start_time
-            return {
-                "task_id": task_id,
-                "success": False,
-                "output_path": None,
-                "message": context.get(step, {}).get("error"),
-                "duration": total_duration,
-                "pipeline": pipeline_metrics,
-            }
+            self.update_state(
+                state="FAILURE",
+                meta={"progress": progress, "message": error_msg},
+            )
+            raise Exception(error_msg)
+        progress = int(((i + 1) / total_steps) * 100)
+        self.update_state(
+            state="PROGRESS",
+            meta={"progress": progress, "message": f"Completado {step}"},
+        )
 
     total_duration = time.time() - start_time
     final_result = context.get("conversion", {})
+    self.update_state(
+        state="PROGRESS", meta={"progress": 100, "message": "Proceso completado"}
+    )
     with app.app_context():
         conv = Conversion.query.filter_by(task_id=task_id).first()
         if conv:

--- a/frontend/src/components/ConversionPanel.tsx
+++ b/frontend/src/components/ConversionPanel.tsx
@@ -9,6 +9,8 @@ interface ConversionPanelProps {
 const ConversionPanel: React.FC<ConversionPanelProps> = ({ file }) => {
   const [taskId, setTaskId] = useState<string | null>(null);
   const [status, setStatus] = useState<string | null>(null);
+  const [progress, setProgress] = useState<number>(0);
+  const [statusMessage, setStatusMessage] = useState<string>('');
   const [error, setError] = useState<string | null>(null);
   const [isConverting, setIsConverting] = useState<boolean>(false);
   const [isAnalyzing, setIsAnalyzing] = useState<boolean>(false);
@@ -63,6 +65,8 @@ const ConversionPanel: React.FC<ConversionPanelProps> = ({ file }) => {
     setError(null);
     setTaskId(null);
     setStatus(null);
+    setProgress(0);
+    setStatusMessage('');
     setIsConverting(true);
     try {
       const formData = new FormData();
@@ -106,9 +110,18 @@ const ConversionPanel: React.FC<ConversionPanelProps> = ({ file }) => {
         }
         const data = await res.json();
         setStatus(data.status);
-        if (data.status === 'SUCCESS') {
+        if (data.status === 'PROGRESS') {
+          if (typeof data.progress === 'number') {
+            setProgress(data.progress);
+          }
+          if (data.message) {
+            setStatusMessage(data.message);
+          }
+        } else if (data.status === 'SUCCESS') {
           clearInterval(interval);
           setIsConverting(false);
+          setProgress(100);
+          setStatusMessage('Conversión completada');
           if (data.result && data.result.output_path) {
             const downloadRes = await fetch(data.result.output_path);
             const blob = await downloadRes.blob();
@@ -125,6 +138,7 @@ const ConversionPanel: React.FC<ConversionPanelProps> = ({ file }) => {
           clearInterval(interval);
           setIsConverting(false);
           setError(data.error || 'Error en la conversión');
+          setStatusMessage('');
         }
       } catch (err: any) {
         clearInterval(interval);
@@ -161,8 +175,19 @@ const ConversionPanel: React.FC<ConversionPanelProps> = ({ file }) => {
       <button onClick={startConversion} disabled={!file || !selectedPipeline || isConverting}>
         {isConverting ? 'Convirtiendo...' : 'Enviar a convertir'}
       </button>
+      {isConverting && (
+        <div className="w-full mt-4">
+          <div className="w-full bg-gray-200 rounded h-4">
+            <div
+              className="bg-blue-500 h-4 rounded"
+              style={{ width: `${progress}%` }}
+            ></div>
+          </div>
+          <p className="mt-2 text-sm">{statusMessage || `Progreso: ${progress}%`}</p>
+        </div>
+      )}
       {taskId && <p>Task ID: {taskId}</p>}
-      {status && <p>Estado: {status}</p>}
+      {status && !isConverting && <p>Estado: {status}</p>}
       {error && <p className="error">{error}</p>}
     </div>
   );


### PR DESCRIPTION
## Summary
- Report conversion progress and failure messages from Celery task
- Surface task progress metadata through `/api/status`
- Show progress bar and status text during conversions

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pypandoc')*
- `npm test` *(fails: Pipeline selector not implemented)*

------
https://chatgpt.com/codex/tasks/task_e_68c56aa9a5a883208f3f6d70cffdb778