### PR TITLE
Add technical pipeline with MathML support

### DIFF
--- a/docs/ANALISIS_ANCLORA_PDF2EPUB.md
+++ b/docs/ANALISIS_ANCLORA_PDF2EPUB.md
@@ -1,0 +1,8 @@
+# Análisis Pipeline Técnico
+
+Se incorpora `technical_pipeline` para mejorar la conversión de documentos con tablas o fórmulas.
+
+- **pdf2htmlEX** transforma el PDF en HTML conservando la estructura de tablas.
+- **pypandoc --mathml** genera EPUB con soporte MathML, preservando símbolos matemáticos.
+
+`SequenceEvaluator` recomienda este pipeline cuando el análisis detecta tablas o caracteres matemáticos, optimizando la fidelidad de documentos técnicos.


### PR DESCRIPTION
## Summary
- add `technical_pipeline` combining pdf2htmlEX and pandoc `--mathml`
- suggest technical pipeline when tables or math symbols detected
- document new pipeline and update task state handling

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c576eb19408320af672ca7ba38f177