### PR TITLE
Render math formulas in preview modal

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "anclora-pdf2epub-frontend",
       "version": "0.1.0",
       "dependencies": {
+        "mathjax": "^4.0.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-dropzone": "^14.2.3",
@@ -809,6 +810,12 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@mathjax/mathjax-newcm-font": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@mathjax/mathjax-newcm-font/-/mathjax-newcm-font-4.0.0.tgz",
+      "integrity": "sha512-kpsJgIF4FpWiwIkFgOPmWwy5GXfL25spmJJNg27HQxPddmEL8Blx0jn2BuU/nlwjM/9SnYpEfDrWiAMgLPlB8Q==",
+      "license": "Apache-2.0"
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -3445,6 +3452,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/mathjax": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mathjax/-/mathjax-4.0.0.tgz",
+      "integrity": "sha512-ThMPHiPl9ibZBInAmfoTCNq9MgCdH7ChIQ9YhKFc325noJ4DMzy9/Q14qdcuPzVJjEmC3kyXhwnERZWX3hbWzQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@mathjax/mathjax-newcm-font": "^4.0.0"
       }
     },
     "node_modules/merge2": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "mathjax": "^4.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-dropzone": "^14.2.3",
@@ -16,14 +17,14 @@
     "test": "vitest --environment jsdom"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.1.2",
+    "@testing-library/react": "^14.0.0",
     "@vitejs/plugin-react": "^4.0.0",
     "autoprefixer": "^10.4.16",
+    "jsdom": "^22.1.0",
     "postcss": "^8.4.31",
     "tailwindcss": "^3.3.5",
     "vite": "^5.0.0",
-    "vitest": "^0.34.6",
-    "@testing-library/react": "^14.0.0",
-    "@testing-library/jest-dom": "^6.1.2",
-    "jsdom": "^22.1.0"
+    "vitest": "^0.34.6"
   }
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -5,3 +5,7 @@
 body {
   @apply bg-gray-100 text-gray-900 dark:bg-gray-900 dark:text-gray-100;
 }
+
+.MathJax {
+  color: inherit;
+}


### PR DESCRIPTION
## Summary
- add MathJax dependency and inline typesetting in PreviewModal
- style MathJax output to follow dark mode colors

## Testing
- `npm test` *(fails: Pipeline selector not implemented)*

------
https://chatgpt.com/codex/tasks/task_e_68c576ed6ef08320847441b58a50fa7b