### PR TITLE
Add tests for tables and math rendering

### DIFF
--- a/backend/tests/test_converter.py
+++ b/backend/tests/test_converter.py
@@ -151,6 +151,33 @@ def test_rapid_converter_generates_epub(tmp_path):
     os.remove(pdf_path)
 
 
+def test_rapid_converter_preserves_tables(tmp_path):
+    pdf_path = _create_simple_pdf("<table><tr><td>Cell</td></tr></table>")
+    output_path = tmp_path / "table.epub"
+    analysis = _analysis_for(pdf_path)
+    converter = RapidConverter()
+    converter.convert(pdf_path, str(output_path), analysis, metadata={"title": "Table"})
+    import zipfile
+    with zipfile.ZipFile(output_path, 'r') as zf:
+        content = zf.read('EPUB/page_1.xhtml').decode('utf-8')
+    assert '<table>' in content
+    os.remove(pdf_path)
+
+
+def test_rapid_converter_handles_math(tmp_path):
+    mathml = "<math><mi>x</mi><msup><mi>x</mi><mn>2</mn></msup></math>"
+    pdf_path = _create_simple_pdf(mathml)
+    output_path = tmp_path / "math.epub"
+    analysis = _analysis_for(pdf_path)
+    converter = RapidConverter()
+    converter.convert(pdf_path, str(output_path), analysis, metadata={"title": "Math"})
+    import zipfile
+    with zipfile.ZipFile(output_path, 'r') as zf:
+        content = zf.read('EPUB/page_1.xhtml').decode('utf-8')
+    assert ('<math' in content) or ('<img' in content and 'alt=' in content)
+    os.remove(pdf_path)
+
+
 def test_suggest_best_pipeline_returns_sequence_and_metrics():
     pdf_path = _create_simple_pdf()
     converter = EnhancedPDFToEPUBConverter()

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "anclora-pdf2epub-frontend",
       "version": "0.1.0",
       "dependencies": {
+        "katex": "^0.16.9",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-dropzone": "^14.2.3",
@@ -3350,6 +3351,31 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/katex": {
+      "version": "0.16.22",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.22.tgz",
+      "integrity": "sha512-XCHRdUw4lf3SKBaJe4EvgqIuWwkPSo9XoeO8GjQW94Bp7TWv9hNhzZjZ+OH9yf1UmLygb7DIT5GSFQiyt16zYg==",
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
+    },
+    "node_modules/katex/node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/lilconfig": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,8 @@
     "react-dom": "^18.2.0",
     "react-dropzone": "^14.2.3",
     "react-router-dom": "^6.22.3",
-    "typescript": "^5.2.2"
+    "typescript": "^5.2.2",
+    "katex": "^0.16.9"
   },
   "scripts": {
     "start": "vite",

--- a/frontend/src/__tests__/previewModal.test.tsx
+++ b/frontend/src/__tests__/previewModal.test.tsx
@@ -20,3 +20,14 @@ test('loads pages and navigates', async () => {
   fireEvent.click(screen.getByText(/siguiente/i));
   await waitFor(() => expect(screen.getByText('dos')).toBeInTheDocument());
 });
+
+test('renders math formulas with KaTeX', async () => {
+  const fetchMock = vi.fn(() =>
+    Promise.resolve({ ok: true, json: () => Promise.resolve({ pages: ['<p>$$x^2$$</p>'] }) })
+  );
+  // @ts-ignore
+  global.fetch = fetchMock;
+  render(<PreviewModal taskId="1" onClose={() => {}} />);
+  await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+  await waitFor(() => expect(document.querySelector('.katex')).not.toBeNull());
+});

--- a/frontend/src/components/PreviewModal.tsx
+++ b/frontend/src/components/PreviewModal.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useAuth } from '../AuthContext';
+import renderMathInElement from 'katex/contrib/auto-render';
 
 interface PreviewModalProps {
   taskId: string;
@@ -23,6 +24,17 @@ const PreviewModal: React.FC<PreviewModalProps> = ({ taskId, onClose }) => {
     };
     load();
   }, [taskId, token]);
+
+  useEffect(() => {
+    document.querySelectorAll('.preview-body').forEach((el) => {
+      renderMathInElement(el as HTMLElement, {
+        delimiters: [
+          { left: '$$', right: '$$', display: true },
+          { left: '\\(', right: '\\)', display: false },
+        ],
+      });
+    });
+  }, [pages, index]);
 
   const next = () => setIndex((i) => Math.min(i + 1, pages.length - 1));
   const prev = () => setIndex((i) => Math.max(i - 1, 0));


### PR DESCRIPTION
## Summary
- add backend tests for table and math detection in EPUB output
- render math formulas in PreviewModal with KaTeX and test

## Testing
- `pytest backend/tests/test_converter.py`
- `npm test -- --run src/__tests__/previewModal.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c57afb49bc8320ab56909819a72974