### PR TITLE
Align volume mounts with app config paths

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,8 +47,8 @@ services:
       - DATABASE_URL=${DATABASE_URL}
     volumes:
       - ./backend:/app
-      - uploads:/${UPLOAD_FOLDER}
-      - results:/${RESULTS_FOLDER}
+      - uploads:/app/${UPLOAD_FOLDER}
+      - results:/app/${RESULTS_FOLDER}
     depends_on:
       - redis
     networks:
@@ -69,8 +69,8 @@ services:
       - WORKER_METRICS_PORT=${WORKER_METRICS_PORT}
     volumes:
       - ./backend:/app
-      - uploads:/${UPLOAD_FOLDER}
-      - results:/${RESULTS_FOLDER}
+      - uploads:/app/${UPLOAD_FOLDER}
+      - results:/app/${RESULTS_FOLDER}
     depends_on:
       - redis
       - db


### PR DESCRIPTION
## Summary
- Mount `uploads` and `results` volumes under `/app` so Flask uses the correct directories

## Testing
- `pytest` *(fails: backend/tests/test_tasks.py::test_convert_pdf_to_epub_failure)*

------
https://chatgpt.com/codex/tasks/task_e_68c57f90d44c8320a482fd6f00fd7cff