### PR TITLE
Add wait-for-db script for backend startup

### DIFF
--- a/backend/wait-for-db.sh
+++ b/backend/wait-for-db.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+# wait-for-db.sh - wait until PostgreSQL is ready
+set -e
+
+until python - <<'PY'
+import os, sys, psycopg2
+try:
+    conn = psycopg2.connect(os.environ['DATABASE_URL'])
+    conn.close()
+except Exception:
+    sys.exit(1)
+PY
+ do
+  echo "Waiting for PostgreSQL..."
+  sleep 1
+done
+
+echo "PostgreSQL is up - executing command"
+exec "$@"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,6 +51,8 @@ services:
       - results:/${RESULTS_FOLDER}
     depends_on:
       - redis
+      - db
+    command: ["./wait-for-db.sh", "python", "main.py"]
     networks:
       - anclora-network
 


### PR DESCRIPTION
## Summary
- ensure backend waits for PostgreSQL by adding `db` to `depends_on`
- start backend via new `wait-for-db.sh` script that polls the database before running the app

## Testing
- `pip install requests`
- `pytest` *(fails: backend/tests/test_tasks.py::test_convert_pdf_to_epub_failure)*

------
https://chatgpt.com/codex/tasks/task_e_68c57f960f048320ab7e5ea4c168c6dd