### PR TITLE
feat: enrich EPUB conversion with PDF metadata

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -15,6 +15,7 @@ Flask-Limiter==3.5.0
 prometheus-client==0.20.0
 python-magic==0.4.27
 pypandoc==1.15
+pypdf==3.17.4
 
 pytest==7.4.3
 pytest-flask==1.3.0


### PR DESCRIPTION
## Summary
- extract title, author and language from PDFs using pypdf with langdetect fallback
- merge extracted metadata into conversion pipeline and include in EPUB output
- cover metadata extraction and language detection with tests

## Testing
- `pytest` *(fails: pipelines module not implemented, missing engine metadata in tasks, etc.)*
- `pytest backend/tests/test_converter.py::test_enhanced_converter_uses_recommended_engine backend/tests/test_converter.py::test_converter_extracts_metadata_and_detects_language`


------
https://chatgpt.com/codex/tasks/task_e_68c56aa80c3c8320b82b6a638fc15dd0