### PR TITLE
feat: improve responsive layout

### DIFF
--- a/frontend/src/components/ConversionPanel.tsx
+++ b/frontend/src/components/ConversionPanel.tsx
@@ -151,46 +151,54 @@ const ConversionPanel: React.FC<ConversionPanelProps> = ({ file }) => {
   };
 
   return (
-    <div className="conversion-panel">
-      {isAnalyzing && <p>Analizando...</p>}
-      {pipelines.length > 0 && (
-        <div className="pipeline-list">
-          <h3>Opciones de conversión</h3>
-          <ul>
-            {pipelines.map((p) => (
-              <li key={p.id}>
-                <label>
-                  <input
-                    type="radio"
-                    name="pipeline"
-                    value={p.id}
-                    checked={selectedPipeline === p.id}
-                    onChange={() => setSelectedPipeline(p.id)}
-                  />
-                  {p.quality} - {p.estimated_time}s
-                </label>
-              </li>
-            ))}
-          </ul>
-        </div>
-      )}
-      <button onClick={startConversion} disabled={!file || !selectedPipeline || isConverting}>
-        {isConverting ? 'Convirtiendo...' : 'Enviar a convertir'}
-      </button>
-      {isConverting && (
-        <div className="w-full mt-4">
-          <div className="w-full bg-gray-200 rounded h-4">
-            <div
-              className="bg-blue-500 h-4 rounded"
-              style={{ width: `${progress}%` }}
-            ></div>
+    <div className="conversion-panel p-4 md:p-6 text-sm md:text-base">
+      {isAnalyzing && <p className="mb-4">Analizando...</p>}
+      <div className="flex flex-col md:flex-row md:items-start md:space-x-6 space-y-4 md:space-y-0">
+        {pipelines.length > 0 && (
+          <div className="pipeline-list flex-1">
+            <h3 className="font-semibold mb-2">Opciones de conversión</h3>
+            <ul className="space-y-2">
+              {pipelines.map((p) => (
+                <li key={p.id} className="flex items-center space-x-2">
+                  <label className="flex items-center space-x-2">
+                    <input
+                      type="radio"
+                      name="pipeline"
+                      value={p.id}
+                      checked={selectedPipeline === p.id}
+                      onChange={() => setSelectedPipeline(p.id)}
+                    />
+                    <span>{p.quality} - {p.estimated_time}s</span>
+                  </label>
+                </li>
+              ))}
+            </ul>
           </div>
-          <p className="mt-2 text-sm">{statusMessage || `Progreso: ${progress}%`}</p>
+        )}
+        <div className="flex flex-col space-y-4 flex-1">
+          <button
+            onClick={startConversion}
+            disabled={!file || !selectedPipeline || isConverting}
+            className="px-4 py-2 bg-blue-600 text-white rounded disabled:opacity-50"
+          >
+            {isConverting ? 'Convirtiendo...' : 'Enviar a convertir'}
+          </button>
+          {isConverting && (
+            <div className="w-full">
+              <div className="w-full bg-gray-200 rounded h-4">
+                <div
+                  className="bg-blue-500 h-4 rounded"
+                  style={{ width: `${progress}%` }}
+                ></div>
+              </div>
+              <p className="mt-2">{statusMessage || `Progreso: ${progress}%`}</p>
+            </div>
+          )}
+          {taskId && <p>Task ID: {taskId}</p>}
+          {status && !isConverting && <p>Estado: {status}</p>}
+          {error && <p className="error">{error}</p>}
         </div>
-      )}
-      {taskId && <p>Task ID: {taskId}</p>}
-      {status && !isConverting && <p>Estado: {status}</p>}
-      {error && <p className="error">{error}</p>}
+      </div>
     </div>
   );
 };

--- a/frontend/src/components/HistoryView.tsx
+++ b/frontend/src/components/HistoryView.tsx
@@ -34,43 +34,76 @@ const HistoryView: React.FC = () => {
   }, [token]);
 
   return (
-    <div className="history-view">
-      {error && <p className="error">{error}</p>}
-      <table>
-        <thead>
-          <tr>
-            <th>Miniatura</th>
-            <th>Estado</th>
-            <th>Fecha</th>
-            <th>Acciones</th>
-          </tr>
-        </thead>
-        <tbody>
-          {history.map(item => (
-            <tr key={item.task_id}>
-              <td>
-                {item.thumbnail_url && (
-                  <img src={item.thumbnail_url} alt={item.task_id} width={60} />
-                )}
-              </td>
-              <td>{item.status}</td>
-              <td>{item.created_at ? new Date(item.created_at).toLocaleString() : '-'}</td>
-              <td>
-                {item.output_path && (
-                  <>
-                    <a href={item.output_path} download>
-                      Descargar
-                    </a>{' '}
-                    <a href={item.output_path} target="_blank" rel="noopener noreferrer">
-                      Ver
-                    </a>
-                  </>
-                )}
-              </td>
+    <div className="history-view p-4 md:p-6 text-sm md:text-base">
+      {error && <p className="error mb-4">{error}</p>}
+
+      {/* Card view for mobile */}
+      <div className="md:hidden space-y-4">
+        {history.map(item => (
+          <div key={item.task_id} className="bg-white shadow rounded-lg p-4">
+            {item.thumbnail_url && (
+              <img
+                src={item.thumbnail_url}
+                alt={item.task_id}
+                className="mb-2 w-24 h-auto"
+              />
+            )}
+            <div className="flex justify-between mb-2">
+              <span className="font-medium">{item.status}</span>
+              <span>{item.created_at ? new Date(item.created_at).toLocaleString() : '-'}</span>
+            </div>
+            {item.output_path && (
+              <div className="flex space-x-4">
+                <a href={item.output_path} download>
+                  Descargar
+                </a>
+                <a href={item.output_path} target="_blank" rel="noopener noreferrer">
+                  Ver
+                </a>
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+
+      {/* Table view for desktop */}
+      <div className="hidden md:block overflow-x-auto">
+        <table className="min-w-full">
+          <thead>
+            <tr className="text-left">
+              <th className="p-2 md:p-4">Miniatura</th>
+              <th className="p-2 md:p-4">Estado</th>
+              <th className="p-2 md:p-4">Fecha</th>
+              <th className="p-2 md:p-4">Acciones</th>
             </tr>
-          ))}
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            {history.map(item => (
+              <tr key={item.task_id} className="border-t">
+                <td className="p-2 md:p-4">
+                  {item.thumbnail_url && (
+                    <img src={item.thumbnail_url} alt={item.task_id} width={60} />
+                  )}
+                </td>
+                <td className="p-2 md:p-4">{item.status}</td>
+                <td className="p-2 md:p-4">{item.created_at ? new Date(item.created_at).toLocaleString() : '-'}</td>
+                <td className="p-2 md:p-4">
+                  {item.output_path && (
+                    <>
+                      <a href={item.output_path} download>
+                        Descargar
+                      </a>{' '}
+                      <a href={item.output_path} target="_blank" rel="noopener noreferrer">
+                        Ver
+                      </a>
+                    </>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- stack conversion controls vertically on mobile and horizontally on larger screens
- render history items as cards on small screens while keeping desktop table
- apply responsive typography and spacing across views

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c7879b95d483209e26d4800fb5b8d7