### PR TITLE
feat: improve header accessibility

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -100,7 +100,7 @@ const Header: React.FC<HeaderProps> = ({ theme, toggleTheme, currentSection, set
               <button
                 key={item.id}
                 onClick={() => setCurrentSection(item.id)}
-                className={`flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium transition-all duration-200 ${
+                className={`flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium transition-all duration-200 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 ${
                   currentSection === item.id
                     ? 'shadow-md'
                     : 'hover:bg-gray-100'
@@ -125,7 +125,7 @@ const Header: React.FC<HeaderProps> = ({ theme, toggleTheme, currentSection, set
             <button
               onClick={toggleTheme}
               aria-label={t('theme.toggle')}
-              className="flex items-center gap-2 px-3 py-2 rounded-lg text-sm font-medium transition-all duration-200 hover:scale-105"
+              className="flex items-center gap-2 px-3 py-2 rounded-lg text-sm font-medium transition-all duration-200 hover:scale-105 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
               style={{
                 background: theme === 'dark'
                   ? 'linear-gradient(90deg, #FFC979 70%, #2EAFC4 100%)'
@@ -165,7 +165,8 @@ const Header: React.FC<HeaderProps> = ({ theme, toggleTheme, currentSection, set
             {/* Botón de Logout */}
             <button
               onClick={handleLogout}
-              className="flex items-center gap-2 px-3 py-2 rounded-lg text-sm font-medium transition-all duration-200 hover:bg-red-50 hover:text-red-600"
+              aria-label={t('navigation.logout')}
+              className="flex items-center gap-2 px-3 py-2 rounded-lg text-sm font-medium transition-all duration-200 hover:bg-red-50 hover:text-red-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
               style={{ color: 'var(--text-secondary)' }}
             >
               <span>🚪</span>
@@ -181,7 +182,7 @@ const Header: React.FC<HeaderProps> = ({ theme, toggleTheme, currentSection, set
               <button
                 key={item.id}
                 onClick={() => setCurrentSection(item.id)}
-                className={`flex flex-col items-center gap-1 px-3 py-2 rounded-lg text-xs font-medium transition-all duration-200 ${
+                className={`flex flex-col items-center gap-1 px-3 py-2 rounded-lg text-xs font-medium transition-all duration-200 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 ${
                   currentSection === item.id
                     ? ''
                     : ''

--- a/frontend/src/components/LanguageSelector.tsx
+++ b/frontend/src/components/LanguageSelector.tsx
@@ -28,7 +28,8 @@ const LanguageSelector: React.FC = () => {
     <div className="relative">
       <button
         onClick={() => setIsOpen(!isOpen)}
-        className="flex items-center space-x-1 px-2 py-1 text-sm font-medium text-gray-600 dark:text-gray-300 hover:text-gray-800 dark:hover:text-gray-100 transition-colors duration-200"
+        aria-label="Select Language"
+        className="flex items-center space-x-1 px-2 py-1 text-sm font-medium text-gray-600 dark:text-gray-300 hover:text-gray-800 dark:hover:text-gray-100 transition-colors duration-200 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
         title="Select Language"
       >
         <span className="text-base">{currentLanguage.flag}</span>
@@ -48,7 +49,11 @@ const LanguageSelector: React.FC = () => {
           {/* Overlay para cerrar el dropdown */}
           <div
             className="fixed inset-0 z-10"
+            role="button"
+            tabIndex={0}
+            aria-label="Close language menu"
             onClick={() => setIsOpen(false)}
+            onKeyDown={(e) => (e.key === 'Enter' || e.key === ' ') && setIsOpen(false)}
           />
 
           {/* Dropdown menu */}
@@ -58,7 +63,7 @@ const LanguageSelector: React.FC = () => {
                 <button
                   key={language.code}
                   onClick={() => changeLanguage(language.code)}
-                  className={`w-full px-3 py-1 text-sm text-left hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors duration-200 ${
+                  className={`w-full px-3 py-1 text-sm text-left hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors duration-200 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 ${
                     i18n.language === language.code
                       ? 'bg-blue-50 dark:bg-blue-900/20 text-blue-600 dark:text-blue-400 font-medium'
                       : 'text-gray-700 dark:text-gray-300'


### PR DESCRIPTION
## Summary
- add focus-visible styles for keyboard navigation
- provide aria labels for icon buttons and make overlay accessible

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68c787a47410832080aa733a4abf61aa