### PR TITLE
feat: add Container component and apply mobile-first design

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,40 @@ open http://localhost
 
 </div>
 
+## 📱 Diseño Mobile-First / Mobile-First Design
+
+### 🇪🇸 Español
+- La interfaz se construye con una filosofía **mobile-first**, aprovechando las utilidades responsivas de Tailwind CSS.
+- Para mantener un ancho máximo coherente en las vistas, envuelve el contenido con el componente `Container`.
+
+```tsx
+import Container from './components/Container';
+
+function Ejemplo() {
+  return (
+    <Container>
+      {/* contenido */}
+    </Container>
+  );
+}
+```
+
+### 🇺🇸 English
+- The UI follows a **mobile-first** approach using Tailwind CSS responsive utilities.
+- Wrap page content with the `Container` component to keep a consistent maximum width across views.
+
+```tsx
+import Container from './components/Container';
+
+function Example() {
+  return (
+    <Container>
+      {/* content */}
+    </Container>
+  );
+}
+```
+
 ## 📞 Contacto / Contact
 
 <div align="center">

--- a/frontend/src/components/Container.tsx
+++ b/frontend/src/components/Container.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+interface ContainerProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+const Container: React.FC<ContainerProps> = ({ children, className = '' }) => {
+  return (
+    <div className={`mx-auto w-full max-w-screen-lg px-4 sm:px-6 ${className}`}>
+      {children}
+    </div>
+  );
+};
+
+export default Container;
+

--- a/frontend/src/components/ConversionHistory.tsx
+++ b/frontend/src/components/ConversionHistory.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { supabase } from '../lib/supabase';
 import { useAuth } from '../AuthContext';
 import { useTranslation } from 'react-i18next';
+import Container from './Container';
 
 interface HistoryItem {
   task_id: string;
@@ -70,7 +71,7 @@ const ConversionHistory: React.FC = () => {
   }
 
   return (
-    <div className="conversion-history">
+    <Container className="conversion-history">
       {error && (
         <div className="bg-red-50 border border-red-200 rounded-lg p-4 mb-4">
           <p className="text-red-700 text-sm font-medium">{t('common.error')}: {error}</p>
@@ -160,7 +161,7 @@ const ConversionHistory: React.FC = () => {
         </table>
         </div>
       )}
-    </div>
+    </Container>
   );
 };
 

--- a/frontend/src/components/FileUploader.tsx
+++ b/frontend/src/components/FileUploader.tsx
@@ -3,6 +3,7 @@ import { useDropzone } from 'react-dropzone';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../AuthContext';
+import Container from './Container';
 
 interface FileUploaderProps {
   onFileSelected?: (file: File) => void;
@@ -287,7 +288,7 @@ const FileUploader: React.FC<FileUploaderProps> = ({ onFileSelected, onConversio
   };
 
   return (
-    <div className="w-full max-w-2xl mx-auto">
+    <Container>
       <div
         {...getRootProps()}
         className={`
@@ -452,7 +453,7 @@ const FileUploader: React.FC<FileUploaderProps> = ({ onFileSelected, onConversio
           </p>
         </div>
       )}
-    </div>
+    </Container>
   );
 };
 

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useAuth } from '../AuthContext';
 import { useTranslation } from 'react-i18next';
 import LanguageSelector from './LanguageSelector';
+import Container from './Container';
 
 interface HeaderProps {
   theme: 'light' | 'dark';
@@ -77,7 +78,7 @@ const Header: React.FC<HeaderProps> = ({ theme, toggleTheme, currentSection, set
               borderColor: 'var(--border-color)',
               boxShadow: 'var(--shadow-sm)'
             }}>
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+      <Container>
         <div className="flex items-center justify-between h-16">
           {/* Logo y Marca */}
           <div className="flex items-center gap-4">
@@ -197,7 +198,7 @@ const Header: React.FC<HeaderProps> = ({ theme, toggleTheme, currentSection, set
             ))}
           </nav>
         </div>
-      </div>
+      </Container>
     </header>
   );
 };


### PR DESCRIPTION
## Summary
- add reusable Container wrapper with responsive spacing
- refactor Header, FileUploader, ConversionHistory to use Container
- document mobile-first design and Container usage in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c787ab48148320bdb404f830e07bd5