### PR TITLE
feat: add i18n support with language selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,11 @@ open http://localhost
 - **[📚 Complete README](README.en.md)** - Full documentation in English
 - **[🌍 Internationalization](INTERNATIONALIZATION.md)** - Languages and translations guide
 
+### 🌐 Agregar nuevas cadenas traducibles / Adding new translatable strings
+1. Agrega la clave y su traducción en `frontend/src/locales/es.json` y `frontend/src/locales/en.json`.
+2. Usa la función `t('clave')` desde `react-i18next` en los componentes React.
+3. El idioma seleccionado se guarda en `localStorage` y está disponible a través de `AuthContext`.
+
 ## ✨ Características Principales / Key Features
 
 ### 🇪🇸 Español

--- a/frontend/src/AuthContext.tsx
+++ b/frontend/src/AuthContext.tsx
@@ -8,6 +8,7 @@ import React, {
 } from 'react';
 import { supabase } from './lib/supabase';
 import type { User, Session } from '@supabase/supabase-js';
+import i18n from './i18n';
 
 interface AuthContextType {
   user: User | null;
@@ -17,6 +18,8 @@ interface AuthContextType {
   login: (email: string, password: string) => Promise<void>;
   register: (email: string, password: string) => Promise<void>;
   logout: () => Promise<void>;
+  language: string;
+  setLanguage: (lang: string) => void;
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
@@ -26,6 +29,7 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
   const [session, setSession] = useState<Session | null>(null);
   const [token, setToken] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
+  const [language, setLanguage] = useState<string>(() => localStorage.getItem('language') || localStorage.getItem('i18nextLng') || 'es');
   const refreshTimer = useRef<NodeJS.Timeout | null>(null);
 
   const scheduleRefresh = (currentSession: Session | null) => {
@@ -67,9 +71,14 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
       setUser(null);
       setSession(null);
       setToken(null);
-      alert('Tu sesión ha expirado. Por favor, inicia sesión de nuevo.');
+      alert(i18n.t('auth.sessionExpired'));
     }
   };
+
+  useEffect(() => {
+    i18n.changeLanguage(language);
+    localStorage.setItem('language', language);
+  }, [language]);
 
   useEffect(() => {
     // Get initial session
@@ -130,7 +139,7 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
   const token = session?.access_token ?? null;
 
   return (
-    <AuthContext.Provider value={{ user, session, token, loading, login, register, logout }}>
+    <AuthContext.Provider value={{ user, session, token, loading, login, register, logout, language, setLanguage }}>
       {children}
     </AuthContext.Provider>
   );

--- a/frontend/src/LoginForm.tsx
+++ b/frontend/src/LoginForm.tsx
@@ -41,7 +41,7 @@ const LoginForm: React.FC = () => {
           <div className="inline-flex items-center justify-center w-16 h-16 rounded-xl mb-4 p-2" style={{ background: 'var(--gradient-hero)' }}>
             <img
               src="/images/iconos/Anclora PDF2EPUB fodo transparente.png"
-              alt="Anclora PDF2EPUB"
+              alt={t('app.title')}
               className="w-full h-full object-contain"
             />
           </div>
@@ -53,7 +53,7 @@ const LoginForm: React.FC = () => {
         <div className="card animate-slide-in">
           <div className="mb-6">
             <h2 className="text-2xl font-semibold text-center mb-2">{t('auth.login')}</h2>
-            <p className="text-center text-gray-600">Accede a tu cuenta para continuar</p>
+            <p className="text-center text-gray-600">{t('auth.loginSubtitle')}</p>
           </div>
 
           {error && (
@@ -127,7 +127,7 @@ const LoginForm: React.FC = () => {
 
         {/* Footer */}
         <div className="text-center mt-8 text-sm text-gray-500">
-          <p>© 2024 Anclora. Todos los derechos reservados.</p>
+          <p>{t('app.copyright')}</p>
         </div>
       </div>
     </div>

--- a/frontend/src/RegisterForm.tsx
+++ b/frontend/src/RegisterForm.tsx
@@ -27,7 +27,7 @@ const RegisterForm: React.FC = () => {
     }
 
     if (password.length < 6) {
-      setError('La contraseña debe tener al menos 6 caracteres');
+      setError(t('auth.passwordMin'));
       setIsLoading(false);
       return;
     }
@@ -55,7 +55,7 @@ const RegisterForm: React.FC = () => {
           <div className="inline-flex items-center justify-center w-16 h-16 rounded-xl mb-4 p-2" style={{ background: 'var(--gradient-press)' }}>
             <img
               src="/images/iconos/Anclora PDF2EPUB fodo transparente.png"
-              alt="Anclora PDF2EPUB"
+              alt={t('app.title')}
               className="w-full h-full object-contain"
             />
           </div>
@@ -67,7 +67,7 @@ const RegisterForm: React.FC = () => {
         <div className="card animate-slide-in">
           <div className="mb-6">
             <h2 className="text-2xl font-semibold text-center mb-2">{t('auth.register')}</h2>
-            <p className="text-center text-gray-600">Completa los datos para registrarte</p>
+            <p className="text-center text-gray-600">{t('auth.registerSubtitle')}</p>
           </div>
 
           {error && (
@@ -79,29 +79,29 @@ const RegisterForm: React.FC = () => {
           <form onSubmit={handleSubmit} className="space-y-4">
             <div>
               <label htmlFor="email" className="block text-sm font-medium mb-2">
-                Email
+                {t('auth.email')}
               </label>
               <input
                 id="email"
                 type="email"
-                placeholder="Ingresa tu email"
+                placeholder={t('auth.emailPlaceholder')}
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
                 className="input"
                 required
                 disabled={isLoading}
               />
-              <p className="text-xs text-gray-500 mt-1">Usaremos este email para tu cuenta</p>
+              <p className="text-xs text-gray-500 mt-1">{t('auth.emailHelp')}</p>
             </div>
 
             <div>
               <label htmlFor="password" className="block text-sm font-medium mb-2">
-                Contraseña
+                {t('auth.password')}
               </label>
               <input
                 id="password"
                 type="password"
-                placeholder="Crea una contraseña segura"
+                placeholder={t('auth.passwordPlaceholder')}
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
                 className="input"
@@ -109,17 +109,17 @@ const RegisterForm: React.FC = () => {
                 disabled={isLoading}
                 minLength={6}
               />
-              <p className="text-xs text-gray-500 mt-1">Mínimo 6 caracteres</p>
+              <p className="text-xs text-gray-500 mt-1">{t('auth.passwordMinChars')}</p>
             </div>
 
             <div>
               <label htmlFor="confirmPassword" className="block text-sm font-medium mb-2">
-                Confirmar contraseña
+                {t('auth.confirmPassword')}
               </label>
               <input
                 id="confirmPassword"
                 type="password"
-                placeholder="Repite tu contraseña"
+                placeholder={t('auth.confirmPasswordPlaceholder')}
                 value={confirmPassword}
                 onChange={(e) => setConfirmPassword(e.target.value)}
                 className="input"
@@ -136,23 +136,23 @@ const RegisterForm: React.FC = () => {
               {isLoading ? (
                 <div className="flex items-center gap-2">
                   <div className="w-4 h-4 border-2 border-current border-t-transparent rounded-full animate-spin"></div>
-                  Creando cuenta...
+                  {t('auth.creatingAccount')}
                 </div>
               ) : (
-                'Crear cuenta'
+                t('auth.registerButton')
               )}
             </button>
           </form>
 
           <div className="mt-6 text-center">
             <p className="text-gray-600">
-              ¿Ya tienes cuenta?{' '}
+              {t('auth.hasAccount')}{' '}
               <Link
                 to="/login"
                 className="font-medium hover:underline"
                 style={{ color: 'var(--accent-primary)' }}
               >
-                Inicia sesión aquí
+                {t('auth.login')}
               </Link>
             </p>
           </div>
@@ -160,7 +160,7 @@ const RegisterForm: React.FC = () => {
 
         {/* Footer */}
         <div className="text-center mt-8 text-sm text-gray-500">
-          <p>© 2024 Anclora. Todos los derechos reservados.</p>
+          <p>{t('app.copyright')}</p>
         </div>
       </div>
     </div>

--- a/frontend/src/components/ConversionPanel.tsx
+++ b/frontend/src/components/ConversionPanel.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../AuthContext';
 import PreviewModal from './PreviewModal';
+import { useTranslation } from 'react-i18next';
 
 interface ConversionPanelProps {
   file: File | null;
@@ -20,6 +21,7 @@ const ConversionPanel: React.FC<ConversionPanelProps> = ({ file }) => {
   const [showPreview, setShowPreview] = useState(false);
   const { token, logout } = useAuth();
   const navigate = useNavigate();
+  const { t } = useTranslation();
 
   const analyzeFile = async () => {
     if (!file) return;
@@ -87,7 +89,7 @@ const ConversionPanel: React.FC<ConversionPanelProps> = ({ file }) => {
       }
       const data = await res.json();
       if (!res.ok) {
-        throw new Error(data.error || 'Error en la conversión');
+        throw new Error(data.error || t('conversionPanel.conversionError'));
       }
       setTaskId(data.task_id);
       pollStatus(data.task_id);
@@ -123,7 +125,7 @@ const ConversionPanel: React.FC<ConversionPanelProps> = ({ file }) => {
           clearInterval(interval);
           setIsConverting(false);
           setProgress(100);
-          setStatusMessage('Conversión completada');
+          setStatusMessage(t('conversionPanel.completed'));
           if (data.result && data.result.output_path) {
             const downloadRes = await fetch(data.result.output_path);
             const blob = await downloadRes.blob();
@@ -139,7 +141,7 @@ const ConversionPanel: React.FC<ConversionPanelProps> = ({ file }) => {
         } else if (data.status === 'FAILURE') {
           clearInterval(interval);
           setIsConverting(false);
-          setError(data.error || 'Error en la conversión');
+          setError(data.error || t('conversionPanel.conversionError'));
           setStatusMessage('');
         }
       } catch (err: any) {
@@ -152,10 +154,10 @@ const ConversionPanel: React.FC<ConversionPanelProps> = ({ file }) => {
 
   return (
     <div className="conversion-panel">
-      {isAnalyzing && <p>Analizando...</p>}
+      {isAnalyzing && <p>{t('conversionPanel.analyzing')}</p>}
       {pipelines.length > 0 && (
         <div className="pipeline-list">
-          <h3>Opciones de conversión</h3>
+          <h3>{t('conversionPanel.options')}</h3>
           <ul>
             {pipelines.map((p) => (
               <li key={p.id}>
@@ -167,7 +169,7 @@ const ConversionPanel: React.FC<ConversionPanelProps> = ({ file }) => {
                     checked={selectedPipeline === p.id}
                     onChange={() => setSelectedPipeline(p.id)}
                   />
-                  {p.quality} - {p.estimated_time}s
+                  {t(`engines.${p.quality}`)} - {p.estimated_time}s
                 </label>
               </li>
             ))}
@@ -175,7 +177,7 @@ const ConversionPanel: React.FC<ConversionPanelProps> = ({ file }) => {
         </div>
       )}
       <button onClick={startConversion} disabled={!file || !selectedPipeline || isConverting}>
-        {isConverting ? 'Convirtiendo...' : 'Enviar a convertir'}
+        {isConverting ? t('conversionPanel.converting') : t('conversionPanel.submit')}
       </button>
       {isConverting && (
         <div className="w-full mt-4">
@@ -185,11 +187,11 @@ const ConversionPanel: React.FC<ConversionPanelProps> = ({ file }) => {
               style={{ width: `${progress}%` }}
             ></div>
           </div>
-          <p className="mt-2 text-sm">{statusMessage || `Progreso: ${progress}%`}</p>
+          <p className="mt-2 text-sm">{statusMessage || t('conversionPanel.progress', { progress })}</p>
         </div>
       )}
-      {taskId && <p>Task ID: {taskId}</p>}
-      {status && !isConverting && <p>Estado: {status}</p>}
+      {taskId && <p>{t('conversionPanel.taskId', { id: taskId })}</p>}
+      {status && !isConverting && <p>{t('conversionPanel.status', { status })}</p>}
       {error && <p className="error">{error}</p>}
     </div>
   );

--- a/frontend/src/components/FileUploader.tsx
+++ b/frontend/src/components/FileUploader.tsx
@@ -100,7 +100,7 @@ const FileUploader: React.FC<FileUploaderProps> = ({ onFileSelected, onConversio
 
       const data = await response.json();
       if (!response.ok) {
-        throw new Error(data.error || 'Error en la conversión');
+        throw new Error(data.error || t('fileUploader.conversionError'));
       }
 
       // Conversión iniciada exitosamente
@@ -185,7 +185,7 @@ const FileUploader: React.FC<FileUploaderProps> = ({ onFileSelected, onConversio
 
       const analyzeData = await analyzeRes.json();
       if (!analyzeRes.ok) {
-        throw new Error(analyzeData.error || 'Error al analizar el archivo');
+        throw new Error(analyzeData.error || t('fileUploader.analyzeError'));
       }
 
       // 2. Mostrar análisis y recomendación

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -85,7 +85,7 @@ const Header: React.FC<HeaderProps> = ({ theme, toggleTheme, currentSection, set
                  style={{ background: 'var(--gradient-hero)' }}>
               <img
                 src="/images/iconos/Anclora PDF2EPUB fodo transparente.png"
-                alt="Anclora PDF2EPUB"
+                alt={t('app.title')}
                 className="w-full h-full object-contain"
               />
             </div>

--- a/frontend/src/components/LanguageSelector.tsx
+++ b/frontend/src/components/LanguageSelector.tsx
@@ -1,27 +1,22 @@
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useAuth } from '../AuthContext';
 
 const LanguageSelector: React.FC = () => {
-  const { i18n } = useTranslation();
+  const { language, setLanguage } = useAuth();
+  const { t } = useTranslation();
   const [isOpen, setIsOpen] = useState(false);
 
   const languages = [
-    { code: 'es', label: 'ES', flag: '🇪🇸' },
-    { code: 'en', label: 'EN', flag: '🇬🇧' }
+    { code: 'es', label: t('language.spanish'), flag: '🇪🇸' },
+    { code: 'en', label: t('language.english'), flag: '🇬🇧' }
   ];
 
-  const currentLanguage = languages.find(lang => lang.code === i18n.language) || languages[0];
-
-  // Debug logging
-  console.log('LanguageSelector - i18n.language:', i18n.language);
-  console.log('LanguageSelector - currentLanguage:', currentLanguage);
+  const currentLanguage = languages.find(lang => lang.code === language) || languages[0];
 
   const changeLanguage = (languageCode: string) => {
-    console.log('Changing language to:', languageCode);
-    i18n.changeLanguage(languageCode).then(() => {
-      console.log('Language changed to:', i18n.language);
-      setIsOpen(false);
-    });
+    setLanguage(languageCode);
+    setIsOpen(false);
   };
 
   return (
@@ -29,7 +24,7 @@ const LanguageSelector: React.FC = () => {
       <button
         onClick={() => setIsOpen(!isOpen)}
         className="flex items-center space-x-1 px-2 py-1 text-sm font-medium text-gray-600 dark:text-gray-300 hover:text-gray-800 dark:hover:text-gray-100 transition-colors duration-200"
-        title="Select Language"
+        title={t('language.selectLanguage')}
       >
         <span className="text-base">{currentLanguage.flag}</span>
         <span>{currentLanguage.label}</span>
@@ -54,17 +49,17 @@ const LanguageSelector: React.FC = () => {
           {/* Dropdown menu */}
           <div className="absolute right-0 mt-1 w-20 bg-white dark:bg-gray-800 rounded-md shadow-lg border border-gray-200 dark:border-gray-700 z-20">
             <div className="py-1">
-              {languages.map((language) => (
+              {languages.map((lang) => (
                 <button
-                  key={language.code}
-                  onClick={() => changeLanguage(language.code)}
+                  key={lang.code}
+                  onClick={() => changeLanguage(lang.code)}
                   className={`w-full px-3 py-1 text-sm text-left hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors duration-200 ${
-                    i18n.language === language.code
+                    language === lang.code
                       ? 'bg-blue-50 dark:bg-blue-900/20 text-blue-600 dark:text-blue-400 font-medium'
                       : 'text-gray-700 dark:text-gray-300'
                   }`}
                 >
-                  {language.label}
+                  {lang.label}
                 </button>
               ))}
             </div>

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -2,9 +2,9 @@ import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
 import LanguageDetector from 'i18next-browser-languagedetector';
 
-// Importar las traducciones
-import es from './locales/es.json';
-import en from './locales/en.json';
+// Import translations
+import es from '../locales/es.json';
+import en from '../locales/en.json';
 
 const resources = {
   es: {

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -1,7 +1,8 @@
 {
   "app": {
     "title": "Anclora PDF2EPUB",
-    "subtitle": "Intelligent PDF to EPUB3 conversion"
+    "subtitle": "Intelligent PDF to EPUB3 conversion",
+    "copyright": "© 2024 Anclora. All rights reserved."
   },
   "navigation": {
     "home": "Home",
@@ -25,7 +26,17 @@
     "invalidCredentials": "Invalid credentials",
     "emailRequired": "Email is required",
     "passwordRequired": "Password is required",
-    "passwordMismatch": "Passwords don't match"
+    "passwordMismatch": "Passwords don't match",
+    "loginSubtitle": "Access your account to continue",
+    "registerSubtitle": "Fill in the details to register",
+    "emailPlaceholder": "Enter your email",
+    "emailHelp": "We'll use this email for your account",
+    "passwordPlaceholder": "Create a secure password",
+    "passwordMinChars": "Minimum 6 characters",
+    "passwordMin": "Password must be at least 6 characters",
+    "confirmPasswordPlaceholder": "Repeat your password",
+    "creatingAccount": "Creating account...",
+    "sessionExpired": "Your session has expired. Please log in again."
   },
   "home": {
     "hero": {
@@ -81,7 +92,8 @@
     "pleaseWait": "Please wait...",
     "conversionStarted": "Conversion started successfully!",
     "checkHistory": "Check history to see progress",
-    "conversionError": "Conversion error"
+    "conversionError": "Conversion error",
+    "analyzeError": "Error analyzing file"
   },
   "history": {
     "title": "Conversion History",
@@ -110,6 +122,17 @@
     "rapid": "Rapid",
     "balanced": "Balanced",
     "quality": "High Quality"
+  },
+  "conversionPanel": {
+    "analyzing": "Analyzing...",
+    "options": "Conversion options",
+    "submit": "Send to convert",
+    "converting": "Converting...",
+    "progress": "Progress: {{progress}}%",
+    "taskId": "Task ID: {{id}}",
+    "status": "Status: {{status}}",
+    "conversionError": "Conversion error",
+    "completed": "Conversion completed"
   },
   "common": {
     "loading": "Loading...",

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -1,7 +1,8 @@
 {
   "app": {
     "title": "Anclora PDF2EPUB",
-    "subtitle": "Conversión inteligente de PDF a EPUB3"
+    "subtitle": "Conversión inteligente de PDF a EPUB3",
+    "copyright": "© 2024 Anclora. Todos los derechos reservados."
   },
   "navigation": {
     "home": "Inicio",
@@ -25,7 +26,17 @@
     "invalidCredentials": "Credenciales inválidas",
     "emailRequired": "El correo electrónico es requerido",
     "passwordRequired": "La contraseña es requerida",
-    "passwordMismatch": "Las contraseñas no coinciden"
+    "passwordMismatch": "Las contraseñas no coinciden",
+    "loginSubtitle": "Accede a tu cuenta para continuar",
+    "registerSubtitle": "Completa los datos para registrarte",
+    "emailPlaceholder": "Ingresa tu email",
+    "emailHelp": "Usaremos este email para tu cuenta",
+    "passwordPlaceholder": "Crea una contraseña segura",
+    "passwordMinChars": "Mínimo 6 caracteres",
+    "passwordMin": "La contraseña debe tener al menos 6 caracteres",
+    "confirmPasswordPlaceholder": "Repite tu contraseña",
+    "creatingAccount": "Creando cuenta...",
+    "sessionExpired": "Tu sesión ha expirado. Por favor, inicia sesión de nuevo."
   },
   "home": {
     "hero": {
@@ -81,7 +92,8 @@
     "pleaseWait": "Por favor espera...",
     "conversionStarted": "¡Conversión iniciada exitosamente!",
     "checkHistory": "Revisa el historial para ver el progreso",
-    "conversionError": "Error en la conversión"
+    "conversionError": "Error en la conversión",
+    "analyzeError": "Error al analizar el archivo"
   },
   "history": {
     "title": "Historial de Conversiones",
@@ -110,6 +122,17 @@
     "rapid": "Rápido",
     "balanced": "Equilibrado",
     "quality": "Alta Calidad"
+  },
+  "conversionPanel": {
+    "analyzing": "Analizando...",
+    "options": "Opciones de conversión",
+    "submit": "Enviar a convertir",
+    "converting": "Convirtiendo...",
+    "progress": "Progreso: {{progress}}%",
+    "taskId": "Task ID: {{id}}",
+    "status": "Estado: {{status}}",
+    "conversionError": "Error en la conversión",
+    "completed": "Conversión completada"
   },
   "common": {
     "loading": "Cargando...",


### PR DESCRIPTION
## Summary
- add locales and i18next setup with English and Spanish translations
- expose persistent language selection via AuthContext and LanguageSelector
- internationalize UI components and document adding translations

## Testing
- `npm test` *(fails: react-i18next:: useTranslation: You will need to pass in an i18next instance by using initReactI18next { code: 'NO_I18NEXT_INSTANCE' })*

------
https://chatgpt.com/codex/tasks/task_e_68c787c8e4cc83208823f09fca241d59