### PR TITLE
feat(frontend): add modal component

### DIFF
--- a/frontend/src/__tests__/modal.test.tsx
+++ b/frontend/src/__tests__/modal.test.tsx
@@ -1,0 +1,17 @@
+import { render, screen } from '@testing-library/react';
+import { expect, test } from 'vitest';
+;(globalThis as any).expect = expect;
+await import('@testing-library/jest-dom');
+import React from 'react';
+import Modal from '../components/Modal';
+
+test('does not render when closed', () => {
+  render(<Modal title="Hola" message="Mensaje" type="success" isOpen={false} />);
+  expect(screen.queryByText('Hola')).toBeNull();
+});
+
+test('renders title and message when open', () => {
+  render(<Modal title="Hola" message="Mensaje" type="error" isOpen={true} />);
+  expect(screen.getByText('Hola')).toBeInTheDocument();
+  expect(screen.getByText('Mensaje')).toBeInTheDocument();
+});

--- a/frontend/src/components/Modal.tsx
+++ b/frontend/src/components/Modal.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+
+interface ModalProps {
+  title: string;
+  message: string;
+  type: 'success' | 'error';
+  isOpen: boolean;
+  onClose?: () => void;
+}
+
+const Modal: React.FC<ModalProps> = ({ title, message, type, isOpen, onClose }) => {
+  if (!isOpen) return null;
+
+  const colorClass = type === 'success' ? 'text-green-600' : 'text-red-600';
+
+  return (
+    <div
+      className="fixed inset-0 flex items-center justify-center"
+      style={{ backgroundColor: 'rgba(0, 0, 0, 0.5)' }}
+      onClick={onClose}
+    >
+      <div
+        className="rounded-lg p-6 max-w-sm w-full"
+        style={{ background: 'var(--bg-card)', color: 'var(--text-primary)', boxShadow: 'var(--shadow-md)' }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2 className={`text-lg font-semibold mb-4 ${colorClass}`}>{title}</h2>
+        <p>{message}</p>
+      </div>
+    </div>
+  );
+};
+
+export default Modal;
+


### PR DESCRIPTION
## Summary
- add reusable Modal component with title, message, type, and visibility controls
- cover Modal component with unit tests

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68c793736340832086c89c4d257ce454