### PR TITLE
Replace alerts with toast notifications

### DIFF
--- a/frontend/src/AuthContext.tsx
+++ b/frontend/src/AuthContext.tsx
@@ -9,6 +9,7 @@ import React, {
 import { supabase } from './lib/supabase';
 import type { User, Session } from '@supabase/supabase-js';
 import i18n from './i18n';
+import Toast from './components/Toast';
 
 interface AuthContextType {
   user: User | null;
@@ -31,6 +32,7 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
   const [loading, setLoading] = useState(true);
   const [language, setLanguage] = useState<string>(() => localStorage.getItem('language') || localStorage.getItem('i18nextLng') || 'es');
   const refreshTimer = useRef<NodeJS.Timeout | null>(null);
+  const [toast, setToast] = useState<{ message: string; type: 'info' | 'success' | 'error' } | null>(null);
 
   const scheduleRefresh = (currentSession: Session | null) => {
     if (refreshTimer.current) {
@@ -71,7 +73,7 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
       setUser(null);
       setSession(null);
       setToken(null);
-      alert(i18n.t('auth.sessionExpired'));
+      setToast({ message: i18n.t('auth.sessionExpired'), type: 'error' });
     }
   };
 
@@ -141,6 +143,13 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
   return (
     <AuthContext.Provider value={{ user, session, token, loading, login, register, logout, language, setLanguage }}>
       {children}
+      {toast && (
+        <Toast
+          message={toast.message}
+          type={toast.type}
+          onClose={() => setToast(null)}
+        />
+      )}
     </AuthContext.Provider>
   );
 };

--- a/frontend/src/components/FileUploader.tsx
+++ b/frontend/src/components/FileUploader.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../AuthContext';
 import Container from './Container';
+import Toast from './Toast';
 
 interface FileUploaderProps {
   onFileSelected?: (file: File) => void;
@@ -19,6 +20,7 @@ const FileUploader: React.FC<FileUploaderProps> = ({ onFileSelected, onConversio
   const { t, i18n } = useTranslation();
   const navigate = useNavigate();
   const { user, token } = useAuth();
+  const [toast, setToast] = useState<{ message: string; type: 'info' | 'success' | 'error' } | null>(null);
 
   const PENDING_FILE_KEY = 'pendingFile';
 
@@ -79,7 +81,7 @@ const FileUploader: React.FC<FileUploaderProps> = ({ onFileSelected, onConversio
         `🎯 ${t('fileUploader.usingEngine')}: ${engineName}\n\n` +
         `⏳ ${t('fileUploader.pleaseWait')}`;
 
-      alert(startMessage);
+      setToast({ message: startMessage, type: 'info' });
 
       // Preparar datos para la conversión
       const formData = new FormData();
@@ -109,7 +111,7 @@ const FileUploader: React.FC<FileUploaderProps> = ({ onFileSelected, onConversio
         `🆔 Task ID: ${data.task_id}\n\n` +
         `📊 ${t('fileUploader.checkHistory')}`;
 
-      alert(successMessage);
+      setToast({ message: successMessage, type: 'success' });
 
       // Opcional: llamar al callback si existe
       if (_onConversionStarted) {
@@ -126,7 +128,7 @@ const FileUploader: React.FC<FileUploaderProps> = ({ onFileSelected, onConversio
       setError(error.message);
 
       const errorMessage = `❌ ${t('fileUploader.conversionError')}\n\n${error.message}`;
-      alert(errorMessage);
+      setToast({ message: errorMessage, type: 'error' });
     }
     finally {
       clearPendingFile();
@@ -206,7 +208,7 @@ const FileUploader: React.FC<FileUploaderProps> = ({ onFileSelected, onConversio
           `🎯 ${t('fileUploader.recommendedEngine')}: ${recommendedName}\n\n` +
           `💡 ${t('fileUploader.loginToConvert')}`;
 
-        alert(analysisMessage);
+        setToast({ message: analysisMessage, type: 'info' });
 
         await savePendingFile(fileToUse);
 
@@ -288,6 +290,7 @@ const FileUploader: React.FC<FileUploaderProps> = ({ onFileSelected, onConversio
   };
 
   return (
+    <>
     <Container>
       <div
         {...getRootProps()}
@@ -454,6 +457,14 @@ const FileUploader: React.FC<FileUploaderProps> = ({ onFileSelected, onConversio
         </div>
       )}
     </Container>
+    {toast && (
+      <Toast
+        message={toast.message}
+        type={toast.type}
+        onClose={() => setToast(null)}
+      />
+    )}
+    </>
   );
 };
 

--- a/frontend/src/components/Toast.tsx
+++ b/frontend/src/components/Toast.tsx
@@ -1,0 +1,28 @@
+import React, { useEffect } from 'react';
+
+interface ToastProps {
+  message: string;
+  type?: 'info' | 'success' | 'error';
+  onClose: () => void;
+}
+
+const bgColors = {
+  info: 'bg-blue-500',
+  success: 'bg-green-500',
+  error: 'bg-red-500'
+};
+
+const Toast: React.FC<ToastProps> = ({ message, type = 'info', onClose }) => {
+  useEffect(() => {
+    const timer = setTimeout(onClose, 3000);
+    return () => clearTimeout(timer);
+  }, [onClose]);
+
+  return (
+    <div className={`fixed bottom-4 right-4 px-4 py-2 text-white rounded shadow-lg ${bgColors[type]}`}>
+      {message}
+    </div>
+  );
+};
+
+export default Toast;


### PR DESCRIPTION
## Summary
- add reusable `Toast` component for lightweight notifications
- replace `alert()` usage in `FileUploader` with `Toast` state and rendering
- show toast on session expiration in `AuthContext`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c7937680188320b2f6496f98931514