### PR TITLE
Add fade-in transitions and assertive Toast announcements

### DIFF
--- a/frontend/src/__tests__/toast.test.tsx
+++ b/frontend/src/__tests__/toast.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+import { expect, test } from 'vitest';
+;(globalThis as any).expect = expect;
+await import('@testing-library/jest-dom');
+import Toast from '../components/Toast';
+
+test('announces message and cleans up on close', () => {
+  const Wrapper = () => {
+    const [show, setShow] = React.useState(true);
+    return show ? <Toast message="Hola" onClose={() => setShow(false)} /> : null;
+  };
+
+  render(<Wrapper />);
+  const toast = screen.getByRole('alert');
+  expect(toast).toHaveAttribute('aria-live', 'assertive');
+  expect(screen.getByText('Hola')).toBeInTheDocument();
+  fireEvent.click(screen.getByLabelText(/close/i));
+  expect(screen.queryByText('Hola')).toBeNull();
+});

--- a/frontend/src/components/ConversionPanel.tsx
+++ b/frontend/src/components/ConversionPanel.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../AuthContext';
 import PreviewModal from './PreviewModal';
+import Toast from './Toast';
 import { useTranslation } from 'react-i18next';
 
 interface ConversionPanelProps {
@@ -192,7 +193,7 @@ const ConversionPanel: React.FC<ConversionPanelProps> = ({ file }) => {
       )}
       {taskId && <p>{t('conversionPanel.taskId', { id: taskId })}</p>}
       {status && !isConverting && <p>{t('conversionPanel.status', { status })}</p>}
-      {error && <p className="error">{error}</p>}
+      {error && <Toast message={error} onClose={() => setError(null)} />}
     </div>
   );
 };

--- a/frontend/src/components/PreviewModal.tsx
+++ b/frontend/src/components/PreviewModal.tsx
@@ -49,8 +49,12 @@ const PreviewModal: React.FC<PreviewModalProps> = ({ taskId, onClose }) => {
   const prev = () => setIndex((i) => Math.max(i - 1, 0));
 
   return (
-    <div className="modal-overlay">
-      <div className="modal-content">
+    <div
+      className="modal-overlay transition animate-fade-in"
+      role="dialog"
+      aria-modal="true"
+    >
+      <div className="modal-content transition animate-fade-in" aria-live="assertive">
         <button onClick={onClose}>Cerrar</button>
         {pages.length > 0 ? (
           <div>

--- a/frontend/src/components/Toast.tsx
+++ b/frontend/src/components/Toast.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+
+interface ToastProps {
+  message: string;
+  onClose: () => void;
+}
+
+const Toast: React.FC<ToastProps> = ({ message, onClose }) => {
+  return (
+    <div
+      role="alert"
+      aria-live="assertive"
+      className="fixed bottom-4 right-4 bg-gray-800 text-white px-4 py-2 rounded shadow-md transition animate-fade-in"
+    >
+      <span>{message}</span>
+      <button
+        onClick={onClose}
+        aria-label="Close"
+        className="ml-2 text-white"
+      >
+        &times;
+      </button>
+    </div>
+  );
+};
+
+export default Toast;


### PR DESCRIPTION
## Summary
- add transition and animate-fade-in classes to PreviewModal for smoother appearance
- create reusable Toast component with aria-live="assertive" and fade-in animation
- verify Toast removal from DOM via unit test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c7937a2d7083208f3a58b5e505a6e8