### PR TITLE
refactor: derive token from state

### DIFF
--- a/frontend/src/AuthContext.tsx
+++ b/frontend/src/AuthContext.tsx
@@ -138,8 +138,6 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
     }
   };
 
-  const token = session?.access_token ?? null;
-
   return (
     <AuthContext.Provider value={{ user, session, token, loading, login, register, logout, language, setLanguage }}>
       {children}


### PR DESCRIPTION
## Summary
- remove redundant token constant in AuthContext so provider uses state token

## Testing
- `npm test -- --run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c79f35f4888320a47a4c4547737444