### PR TITLE
Fix FileUploader auth session handling

### DIFF
--- a/frontend/src/components/FileUploader.tsx
+++ b/frontend/src/components/FileUploader.tsx
@@ -19,7 +19,7 @@ const FileUploader: React.FC<FileUploaderProps> = ({ onFileSelected, onConversio
   const [_forceUpdate, setForceUpdate] = useState(0);
   const { t, i18n } = useTranslation();
   const navigate = useNavigate();
-  const { user, token } = useAuth();
+  const { user, token, session } = useAuth();
   const [toast, setToast] = useState<{ message: string; type: 'info' | 'success' | 'error' } | null>(null);
 
   const PENDING_FILE_KEY = 'pendingFile';


### PR DESCRIPTION
## Summary
- include `session` from `useAuth` in `FileUploader`

## Testing
- `npm test`
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_68c7a184512883209f45451529608593