### PR TITLE
test: verify toast accessibility and animation

### DIFF
--- a/frontend/src/__tests__/toast.test.tsx
+++ b/frontend/src/__tests__/toast.test.tsx
@@ -5,7 +5,7 @@ import { expect, test } from 'vitest';
 await import('@testing-library/jest-dom');
 import Toast from '../components/Toast';
 
-test('announces message and cleans up on close', () => {
+test('announces message with proper roles and animations and cleans up on close', () => {
   const Wrapper = () => {
     const [show, setShow] = React.useState(true);
     return show ? <Toast message="Hola" onClose={() => setShow(false)} /> : null;
@@ -13,7 +13,9 @@ test('announces message and cleans up on close', () => {
 
   render(<Wrapper />);
   const toast = screen.getByRole('alert');
+  expect(toast).toHaveAttribute('role', 'alert');
   expect(toast).toHaveAttribute('aria-live', 'assertive');
+  expect(toast).toHaveClass('transition', 'animate-fade-in');
   expect(screen.getByText('Hola')).toBeInTheDocument();
   fireEvent.click(screen.getByLabelText(/close/i));
   expect(screen.queryByText('Hola')).toBeNull();

--- a/frontend/src/components/Toast.tsx
+++ b/frontend/src/components/Toast.tsx
@@ -20,11 +20,14 @@ const Toast: React.FC<ToastProps> = ({ message, variant = 'info', onClose }) => 
     }
   };
 
+  const baseClasses =
+    'fixed bottom-4 right-4 px-4 py-2 rounded shadow-md transition animate-fade-in';
+
   return (
     <div
       role="alert"
       aria-live="assertive"
-      className={`fixed bottom-4 right-4 px-4 py-2 rounded shadow-md transition animate-fade-in ${getToastStyles()}`}
+      className={`${baseClasses} ${getToastStyles()}`}
     >
       <span>{message}</span>
       <button


### PR DESCRIPTION
## Summary
- ensure Toast container has animation classes and proper aria roles
- add tests asserting transition and fade-in classes plus accessibility attributes

## Testing
- `npm test`
- `pytest` *(fails: ImportError: cannot import name 'db' from 'app')*

------
https://chatgpt.com/codex/tasks/task_e_68c7bbc9b72883209d76fd3e2dfac1aa