### PR TITLE
fix: show error toast for conversion errors

### DIFF
--- a/frontend/src/components/ConversionPanel.tsx
+++ b/frontend/src/components/ConversionPanel.tsx
@@ -193,7 +193,13 @@ const ConversionPanel: React.FC<ConversionPanelProps> = ({ file }) => {
       )}
       {taskId && <p>{t('conversionPanel.taskId', { id: taskId })}</p>}
       {status && !isConverting && <p>{t('conversionPanel.status', { status })}</p>}
-      {error && <Toast message={error} onClose={() => setError(null)} />}
+      {error && (
+        <Toast
+          message={error}
+          variant="error"
+          onClose={() => setError(null)}
+        />
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- specify `error` variant for ConversionPanel toast so failure messages render with correct style

## Testing
- `npm test`
- `pytest` *(fails: ImportError: cannot import name 'db' from 'app')*


------
https://chatgpt.com/codex/tasks/task_e_68c7bbc62b688320a4376b33f1aacd62