### PR TITLE
feat(frontend): enhance Toast component

### DIFF
--- a/frontend/src/AuthContext.tsx
+++ b/frontend/src/AuthContext.tsx
@@ -32,7 +32,7 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
   const [loading, setLoading] = useState(true);
   const [language, setLanguage] = useState<string>(() => localStorage.getItem('language') || localStorage.getItem('i18nextLng') || 'es');
   const refreshTimer = useRef<NodeJS.Timeout | null>(null);
-  const [toast, setToast] = useState<{ message: string; type: 'info' | 'success' | 'error' } | null>(null);
+  const [toast, setToast] = useState<{ title: string; message: string; variant: 'success' | 'error' } | null>(null);
 
   const scheduleRefresh = (currentSession: Session | null) => {
     if (refreshTimer.current) {
@@ -73,7 +73,7 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
       setUser(null);
       setSession(null);
       setToken(null);
-      setToast({ message: i18n.t('auth.sessionExpired'), type: 'error' });
+      setToast({ title: 'Error', message: i18n.t('auth.sessionExpired'), variant: 'error' });
     }
   };
 
@@ -143,8 +143,9 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
       {children}
       {toast && (
         <Toast
+          title={toast.title}
           message={toast.message}
-          type={toast.type}
+          variant={toast.variant}
           onClose={() => setToast(null)}
         />
       )}

--- a/frontend/src/__tests__/toast.test.tsx
+++ b/frontend/src/__tests__/toast.test.tsx
@@ -8,12 +8,20 @@ import Toast from '../components/Toast';
 test('announces message and cleans up on close', () => {
   const Wrapper = () => {
     const [show, setShow] = React.useState(true);
-    return show ? <Toast message="Hola" onClose={() => setShow(false)} /> : null;
+    return show ? (
+      <Toast
+        title="Aviso"
+        message="Hola"
+        variant="success"
+        onClose={() => setShow(false)}
+      />
+    ) : null;
   };
 
   render(<Wrapper />);
   const toast = screen.getByRole('alert');
   expect(toast).toHaveAttribute('aria-live', 'assertive');
+  expect(screen.getByText('Aviso')).toBeInTheDocument();
   expect(screen.getByText('Hola')).toBeInTheDocument();
   fireEvent.click(screen.getByLabelText(/close/i));
   expect(screen.queryByText('Hola')).toBeNull();

--- a/frontend/src/components/ConversionPanel.tsx
+++ b/frontend/src/components/ConversionPanel.tsx
@@ -193,7 +193,14 @@ const ConversionPanel: React.FC<ConversionPanelProps> = ({ file }) => {
       )}
       {taskId && <p>{t('conversionPanel.taskId', { id: taskId })}</p>}
       {status && !isConverting && <p>{t('conversionPanel.status', { status })}</p>}
-      {error && <Toast message={error} onClose={() => setError(null)} />}
+      {error && (
+        <Toast
+          title="Error"
+          message={error}
+          variant="error"
+          onClose={() => setError(null)}
+        />
+      )}
     </div>
   );
 };

--- a/frontend/src/components/FileUploader.tsx
+++ b/frontend/src/components/FileUploader.tsx
@@ -20,7 +20,7 @@ const FileUploader: React.FC<FileUploaderProps> = ({ onFileSelected, onConversio
   const { t, i18n } = useTranslation();
   const navigate = useNavigate();
   const { user, token, session } = useAuth();
-  const [toast, setToast] = useState<{ message: string; type: 'info' | 'success' | 'error' } | null>(null);
+  const [toast, setToast] = useState<{ title: string; message: string; variant: 'success' | 'error' } | null>(null);
 
   const PENDING_FILE_KEY = 'pendingFile';
 
@@ -81,7 +81,7 @@ const FileUploader: React.FC<FileUploaderProps> = ({ onFileSelected, onConversio
         `🎯 ${t('fileUploader.usingEngine')}: ${engineName}\n\n` +
         `⏳ ${t('fileUploader.pleaseWait')}`;
 
-      setToast({ message: startMessage, type: 'info' });
+      setToast({ title: 'Info', message: startMessage, variant: 'success' });
 
       // Preparar datos para la conversión
       const formData = new FormData();
@@ -111,7 +111,7 @@ const FileUploader: React.FC<FileUploaderProps> = ({ onFileSelected, onConversio
         `🆔 Task ID: ${data.task_id}\n\n` +
         `📊 ${t('fileUploader.checkHistory')}`;
 
-      setToast({ message: successMessage, type: 'success' });
+      setToast({ title: 'Success', message: successMessage, variant: 'success' });
 
       // Opcional: llamar al callback si existe
       if (_onConversionStarted) {
@@ -128,7 +128,7 @@ const FileUploader: React.FC<FileUploaderProps> = ({ onFileSelected, onConversio
       setError(error.message);
 
       const errorMessage = `❌ ${t('fileUploader.conversionError')}\n\n${error.message}`;
-      setToast({ message: errorMessage, type: 'error' });
+      setToast({ title: 'Error', message: errorMessage, variant: 'error' });
     }
     finally {
       clearPendingFile();
@@ -211,7 +211,7 @@ const FileUploader: React.FC<FileUploaderProps> = ({ onFileSelected, onConversio
           `🎯 ${t('fileUploader.recommendedEngine')}: ${recommendedName}\n\n` +
           `💡 ${t('fileUploader.loginToConvert')}`;
 
-        setToast({ message: analysisMessage, type: 'info' });
+        setToast({ title: 'Info', message: analysisMessage, variant: 'success' });
 
         await savePendingFile(fileToUse);
 
@@ -462,8 +462,9 @@ const FileUploader: React.FC<FileUploaderProps> = ({ onFileSelected, onConversio
     </Container>
     {toast && (
       <Toast
+        title={toast.title}
         message={toast.message}
-        variant={toast.type}
+        variant={toast.variant}
         onClose={() => setToast(null)}
       />
     )}

--- a/frontend/src/components/Toast.tsx
+++ b/frontend/src/components/Toast.tsx
@@ -1,22 +1,21 @@
 import React from 'react';
 
-interface ToastProps {
+export interface ToastProps {
+  title: string;
   message: string;
-  variant?: 'info' | 'success' | 'error';
+  variant: 'success' | 'error';
   onClose: () => void;
 }
 
-const Toast: React.FC<ToastProps> = ({ message, variant = 'info', onClose }) => {
-  // Define styles based on toast type
+export const Toast: React.FC<ToastProps> = ({ title, message, variant, onClose }) => {
+  // Define styles based on toast variant
   const getToastStyles = () => {
     switch (variant) {
       case 'success':
         return 'bg-green-600 text-white';
       case 'error':
-        return 'bg-red-600 text-white';
-      case 'info':
       default:
-        return 'bg-gray-800 text-white';
+        return 'bg-red-600 text-white';
     }
   };
 
@@ -24,13 +23,14 @@ const Toast: React.FC<ToastProps> = ({ message, variant = 'info', onClose }) => 
     <div
       role="alert"
       aria-live="assertive"
-      className={`fixed bottom-4 right-4 px-4 py-2 rounded shadow-md transition animate-fade-in ${getToastStyles()}`}
+      className={`fixed bottom-4 right-4 px-4 py-3 rounded shadow-md transition animate-fade-in ${getToastStyles()}`}
     >
-      <span>{message}</span>
+      <strong className="block font-semibold">{title}</strong>
+      <span className="block mt-1">{message}</span>
       <button
         onClick={onClose}
         aria-label="Close"
-        className="ml-2 text-white hover:text-gray-200"
+        className="absolute top-1 right-2 text-white hover:text-gray-200"
       >
         &times;
       </button>

--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -1,0 +1,1 @@
+export { default as Toast } from './Toast';


### PR DESCRIPTION
## Summary
- add title and success/error variants to Toast component
- update Toast usages across AuthContext, ConversionPanel, and FileUploader
- export Toast for reuse and adjust tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c7bbba5e20832092fc4a5a014f7d1f